### PR TITLE
fix: add id-token: write permission to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,6 +19,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Summary
- Adds `id-token: write` to workflow permissions
- Fixes OIDC token fetch error that caused the Claude Code action to fail

## Test plan
- [ ] Merge this PR
- [ ] Add `@claude` comment to an open issue and verify Claude responds successfully