### PR TITLE
fix: format Google Sheets dates as M/D/YYYY without leading zeros

### DIFF
--- a/app.py
+++ b/app.py
@@ -161,6 +161,7 @@ def upload_to_google_sheets(receipts: list[dict]) -> tuple[int, list[str]]:
             get_or_create_worksheet,
             get_existing_receipts,
             append_receipt,
+            _format_date_for_sheets,
         )
     except ImportError:
         return 0, ["gspread library not installed"]
@@ -206,7 +207,7 @@ def upload_to_google_sheets(receipts: list[dict]) -> tuple[int, list[str]]:
         worksheet, existing_receipts = worksheets[worksheet_title]
 
         receipt_key = (
-            str(receipt.get("date")),
+            _format_date_for_sheets(str(receipt.get("date"))),
             str(receipt.get("amount")),
             str(receipt.get("vendor")),
         )

--- a/main.py
+++ b/main.py
@@ -590,6 +590,7 @@ def upload_to_sheets(receipts: list[dict]):
             get_or_create_worksheet,
             get_existing_receipts,
             append_receipt,
+            _format_date_for_sheets,
         )
     except ImportError:
         print(
@@ -659,7 +660,7 @@ def upload_to_sheets(receipts: list[dict]):
 
         # Create a unique key for the receipt to check for duplicates
         receipt_key = (
-            str(receipt.get("date")),
+            _format_date_for_sheets(str(receipt.get("date"))),
             str(receipt.get("amount")),
             str(receipt.get("vendor")),
         )

--- a/tests/test_sheets.py
+++ b/tests/test_sheets.py
@@ -1,0 +1,32 @@
+"""Tests for sheets.py helper functions."""
+
+from sheets import _format_date_for_sheets
+
+
+class TestFormatDateForSheets:
+    def test_removes_leading_zero_from_month(self):
+        assert _format_date_for_sheets("02/12/2026") == "2/12/2026"
+
+    def test_removes_leading_zero_from_day(self):
+        assert _format_date_for_sheets("12/05/2026") == "12/5/2026"
+
+    def test_removes_leading_zeros_from_both(self):
+        assert _format_date_for_sheets("02/05/2026") == "2/5/2026"
+
+    def test_no_change_when_no_leading_zeros(self):
+        assert _format_date_for_sheets("2/6/2026") == "2/6/2026"
+
+    def test_iso_date_format(self):
+        assert _format_date_for_sheets("2026-02-12") == "2/12/2026"
+
+    def test_two_digit_year(self):
+        assert _format_date_for_sheets("02/05/26") == "2/5/2026"
+
+    def test_empty_string_returns_empty(self):
+        assert _format_date_for_sheets("") == ""
+
+    def test_invalid_date_returns_original(self):
+        assert _format_date_for_sheets("not-a-date") == "not-a-date"
+
+    def test_double_digit_month_and_day(self):
+        assert _format_date_for_sheets("12/31/2026") == "12/31/2026"


### PR DESCRIPTION
Change date output format for Google Sheets from MM/DD/YYYY (e.g. 02/05/2026) to M/D/YYYY (e.g. 2/5/2026) to match the Graham and Sarah Expenses spreadsheet.

Also normalizes dates consistently across duplicate detection logic so that receipts already in the sheet are correctly identified regardless of whether they were written in the old or new format.

Closes #33