### PR TITLE
fix/visual bug key entry

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.0
+current_version = 0.9.1
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/.cursor/bugs/10-DONE-visual-bug-micro-interaction-for-successful-api-key-entry-has-excessive-space.md
+++ b/.cursor/bugs/10-DONE-visual-bug-micro-interaction-for-successful-api-key-entry-has-excessive-space.md
@@ -24,3 +24,5 @@ Streamlit's `stVerticalBlock` flex container inside columns uses a CSS `gap` pro
 ### Fix
 
 Added a targeted CSS override via `st.markdown(unsafe_allow_html=True)` that sets `gap: 0 !important` on `stVerticalBlock` elements within columns inside the API Configuration expander.
+
+<!-- DONE -->

--- a/.cursor/bugs/10-visual-bug-micro-interaction-for-successful-api-key-entry-has-excessive-space.md
+++ b/.cursor/bugs/10-visual-bug-micro-interaction-for-successful-api-key-entry-has-excessive-space.md
@@ -14,3 +14,13 @@ When you go to the app and you successfully enter in an API key, it gives you a 
 <img width="1889" height="1005" alt="Image" src="https://github.com/user-attachments/assets/3b526a62-2142-4d88-b40e-3708aa996b30" />
 
 ## Acceptance criteria
+
+## Status: Resolved
+
+### Root cause
+
+Streamlit's `stVerticalBlock` flex container inside columns uses a CSS `gap` property that created excessive vertical spacing between the text input and the success message.
+
+### Fix
+
+Added a targeted CSS override via `st.markdown(unsafe_allow_html=True)` that sets `gap: 0 !important` on `stVerticalBlock` elements within columns inside the API Configuration expander.

--- a/app.py
+++ b/app.py
@@ -821,7 +821,7 @@ def main_app():
 
     # Footer
     st.divider()
-    st.caption("Receipt Ranger v0.9.0 | Process receipt images with AI")
+    st.caption("Receipt Ranger v0.9.1 | Process receipt images with AI")
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -352,6 +352,21 @@ def render_api_key_section(cookie=None):
             """
         )
 
+        # Reduce vertical gaps between elements inside the API
+        # Configuration columns (fixes excessive space around the
+        # success message after entering an API key).
+        st.markdown(
+            """
+            <style>
+            [data-testid="stExpander"] [data-testid="stColumn"]
+                [data-testid="stVerticalBlock"] {
+                gap: 0 !important;
+            }
+            </style>
+            """,
+            unsafe_allow_html=True,
+        )
+
         col1, col2 = st.columns([1, 2])
 
         with col1:
@@ -370,9 +385,6 @@ def render_api_key_section(cookie=None):
                 if st.button("Change API key", key="change_api_key_btn"):
                     st.session_state.api_key_token = ""
                     if cookie is not None:
-                        # Defer cookie.remove() to the next render via the flag.
-                        # Calling cookie.remove() + st.rerun() inline would abort
-                        # this render before the component JS could execute.
                         st.session_state.api_key_clear_pending = True
                     st.rerun()
             else:
@@ -388,9 +400,6 @@ def render_api_key_section(cookie=None):
                     if cookie is not None:
                         cookie.set("rr_session", token, max_age=7 * 24 * 60 * 60)
                         cookie.set("rr_provider", provider, max_age=7 * 24 * 60 * 60)
-                    # Show immediate feedback without waiting for the cookie
-                    # component's async rerun. Don't call st.rerun() here — it
-                    # would abort this render before the component JS executes.
                     masked = mask_api_key(decrypt_api_key(token) or "")
                     st.success(f"✓ API key configured: `{masked}`")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "receipt-ranger"
-version = "0.9.0"
+version = "0.9.1"
 description = "Receipt scanner that extracts structured data from receipt images using BAML and LLMs"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Fix visual bug where there was a gap between the API key field and the API key success message. 

- **fix: reduce excessive spacing around API key success message**
- **chore: close CFS bugs #10**
- **Bump version: 0.9.0 → 0.9.1**
