### PR TITLE
fix: hide duplicate file thumbnails in Streamlit 1.53+

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.1
+current_version = 0.9.2
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/.cursor/bugs/13-DONE-visual-regression-selected-images-are-shown-twice.md
+++ b/.cursor/bugs/13-DONE-visual-regression-selected-images-are-shown-twice.md
@@ -1,0 +1,18 @@
+---
+github_issue: 54
+---
+# Visual Regression: Selected images are shown twice.
+
+## Working directory
+
+`~/conductor/workspaces/receipt-ranger/caracas`
+
+## Contents
+
+The site is supposed to only show the selected receipts once in the view below the file selector with the thumbnails. But as can be seen in the screenshot, the smaller icons of the same images are shown in the file selection area as well. The file selection area also looks different than before. Instead of an upload button, there's a little cross that's very close to the touch area of one of the Xs to delete an uploaded screenshot. This is a poor UI, and I'm not sure how it got introduced, but we need to go back to how things were, where there's only the thumbnail showing up and there's a larger file uploader. 
+
+I remember specifically hiding the selected image tiles, so I'm not sure why they're showing up again. I also don't know where the little cross came from. But this needs to be fixed. 
+
+<img width="1436" height="711" alt="Image" src="https://github.com/user-attachments/assets/687701bb-ee7e-466b-a2ab-0947fea5b81f" />
+
+## Acceptance criteria

--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,7 @@ processed_receipts.json
 output/
 logs/
 .cursor/tmp/
+.cursor/security/
 data/exclusion_criteria.txt
 data/receipts/
 service_account.json

--- a/app.py
+++ b/app.py
@@ -435,9 +435,21 @@ def render_file_upload():
     st.markdown(
         """
         <style>
-        [data-testid="stFileUploader"] ul { display: none !important; }
-        [data-testid="stFileUploader"] li { display: none !important; }
+        /* Hide native file list rendered by Streamlit's file uploader.
+           We render our own thumbnail grid in render_file_preview(). */
         [data-testid="stFileUploader"] [data-testid="stFileUploaderFile"] {
+            display: none !important;
+        }
+        [data-testid="stFileUploader"] [data-testid="stFileUploaderFileName"] {
+            display: none !important;
+        }
+        [data-testid="stFileUploader"] [data-testid="stFileUploaderDeleteBtn"] {
+            display: none !important;
+        }
+        [data-testid="stFileUploaderFileList"] {
+            display: none !important;
+        }
+        [data-testid="stFileUploaderFileList"] img {
             display: none !important;
         }
         </style>

--- a/app.py
+++ b/app.py
@@ -833,7 +833,7 @@ def main_app():
 
     # Footer
     st.divider()
-    st.caption("Receipt Ranger v0.9.1 | Process receipt images with AI")
+    st.caption("Receipt Ranger v0.9.2 | Process receipt images with AI")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "receipt-ranger"
-version = "0.9.1"
+version = "0.9.2"
 description = "Receipt scanner that extracts structured data from receipt images using BAML and LLMs"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Updated CSS selectors in the file uploader to target Streamlit 1.53+'s `data-testid`-based DOM structure (`stFileUploaderFileList`, `stFileUploaderFileName`, `stFileUploaderDeleteBtn`), replacing the old `ul`/`li` selectors that no longer matched
- Removes the duplicate image thumbnails and misplaced close button that appeared in the upload area (fixes #54)
- Gitignores `.cursor/security/` directory for private security tracking
- Bumps version to 0.9.2

## Test plan

- [x] Verified locally: upload button stays visible after uploading images
- [x] No duplicate thumbnails in the file uploader area
- [x] No small cross/X button replacing the upload area
- [x] Custom thumbnail grid with remove buttons still works
- [x] All pre-existing tests still pass (149 passed, 3 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)