### PR TITLE
Fix duplicate thumbnails in file uploader

### DIFF
--- a/app.py
+++ b/app.py
@@ -440,20 +440,10 @@ def render_file_upload():
         """
         <style>
         /* Hide native file list rendered by Streamlit's file uploader.
-           We render our own thumbnail grid in render_file_preview(). */
-        [data-testid="stFileUploader"] [data-testid="stFileUploaderFile"] {
-            display: none !important;
-        }
-        [data-testid="stFileUploader"] [data-testid="stFileUploaderFileName"] {
-            display: none !important;
-        }
-        [data-testid="stFileUploader"] [data-testid="stFileUploaderDeleteBtn"] {
-            display: none !important;
-        }
-        [data-testid="stFileUploaderFileList"] {
-            display: none !important;
-        }
-        [data-testid="stFileUploaderFileList"] img {
+           We render our own thumbnail grid in render_file_preview().
+           Uses a structural selector (dropzone ~ *) so it works across
+           Streamlit versions regardless of data-testid renames. */
+        [data-testid="stFileUploadDropzone"] ~ * {
             display: none !important;
         }
         </style>


### PR DESCRIPTION
## Summary
- Replaced 5 brittle `data-testid` CSS selectors with a single structural sibling selector (`[data-testid="stFileUploadDropzone"] ~ *`)
- Fixes native file list showing through on mobile Chrome (and potentially other browsers) due to Streamlit renaming internal test IDs across versions

## Test plan
- [ ] Upload receipt images on mobile Chrome and verify only the custom thumbnail grid appears
- [ ] Verify the "Browse files" button and drag-and-drop area still work
- [ ] Verify remove buttons on custom thumbnails still work

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)