### PR TITLE
deploy/upgrade to more professional hosting

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.6
+current_version = 0.10.0
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"8fe5f388-3c2c-457a-b638-4422b65970d5","pid":8289,"procStart":"Sun Apr 26 19:12:29 2026","acquiredAt":1777231114331}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,20 @@
   "permissions": {
     "allow": [
       "Bash(ls:*)",
-      "Bash(gh run view:*)"
+      "Bash(gh run view:*)",
+      "Bash(gh issue:*)",
+      "WebFetch(domain:docs.streamlit.io)",
+      "WebFetch(domain:aws.amazon.com)",
+      "WebFetch(domain:render.com)",
+      "WebFetch(domain:fly.io)",
+      "WebFetch(domain:docs.cloud.google.com)",
+      "WebFetch(domain:docs.render.com)",
+      "WebFetch(domain:docs.digitalocean.com)",
+      "WebFetch(domain:azure.microsoft.com)",
+      "WebFetch(domain:discuss.streamlit.io)",
+      "WebFetch(domain:docs.railway.app)",
+      "WebFetch(domain:railway.app)",
+      "WebFetch(domain:blog.streamlit.io)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,14 @@
       "WebFetch(domain:discuss.streamlit.io)",
       "WebFetch(domain:docs.railway.app)",
       "WebFetch(domain:railway.app)",
-      "WebFetch(domain:blog.streamlit.io)"
+      "WebFetch(domain:blog.streamlit.io)",
+      "Bash(streamlit run *)",
+      "Bash(pkill -f \"streamlit run app.py\")",
+      "Bash(dig receipt-ranger.com +short)",
+      "Bash(dig www.receipt-ranger.com +short)",
+      "Bash(curl -s https://receipt-ranger.com/)",
+      "Bash(git add *)",
+      "Bash(git commit -m ' *)"
     ]
   }
 }

--- a/.cursor/progress/10-DONE-render-migration-handoff.md
+++ b/.cursor/progress/10-DONE-render-migration-handoff.md
@@ -151,3 +151,5 @@ These are not blocking and can be done at the user's pace.
 - **Cloudflare DNS-only:** Render handles its own SSL via Let's Encrypt — Cloudflare proxy (orange cloud) will break SSL/WebSockets.
 - **Ephemeral filesystem:** Render's filesystem resets on each deploy/restart. Receipt images are processed in-memory, so this is not an issue for this app.
 - **Port:** The Dockerfile exposes 8501. Render auto-detects this from the `EXPOSE` directive.
+
+<!-- DONE -->

--- a/.cursor/progress/10-render-migration-handoff.md
+++ b/.cursor/progress/10-render-migration-handoff.md
@@ -3,22 +3,22 @@ github_issue: 60
 ---
 # Handoff: Migration from Streamlit Community Cloud to Render
 
-**Date:** 2026-04-25
+**Date:** 2026-04-25 (research) / 2026-04-26 (migration)
 **GitHub Issue:** #60
-**Status:** Research complete, implementation not started
+**Status:** Migration complete; remaining cleanup items listed at bottom
 
 ---
 
 ## Background
 
-Receipt Ranger is currently deployed on Streamlit Community Cloud (SCC). SCC has several issues that make the app look unprofessional:
+Receipt Ranger was previously deployed on Streamlit Community Cloud (SCC). SCC had several issues that made the app look unprofessional:
 
-- Cold starts / "wake up" screen when the app hasn't been visited recently
+- Cold starts / "wake up" screen when the app hadn't been visited recently
 - "Fork" button and GitHub icon in the top-right corner linking to source code
 - User profile avatar in the bottom-right corner
 - "Made with Streamlit" branding
 
-The goal is to move to a professional deployment that eliminates all of these while keeping Streamlit as the framework.
+The goal was to move to a professional deployment that eliminates all of these while keeping Streamlit as the framework.
 
 ---
 
@@ -30,7 +30,7 @@ Seven platforms were evaluated. The hard constraint is **WebSocket support** —
 
 | Platform | WebSocket | Always-On Cost | Complexity | Verdict |
 |---|---|---|---|---|
-| **Render** | YES | $7/mo (Starter) | LOW | **RECOMMENDED** |
+| **Render** | YES | $7/mo (Starter) | LOW | **CHOSEN** |
 | **Railway** | YES | $5-10/mo | VERY LOW | Strong alternative |
 | **AWS EC2** | YES (nginx) | $10-14/mo | MEDIUM | Viable but high ops burden |
 | **AWS ECS Fargate** | YES (ALB) | $20-22/mo | HIGH | ALB cost alone exceeds Render |
@@ -57,69 +57,97 @@ Seven platforms were evaluated. The hard constraint is **WebSocket support** —
 
 ---
 
-## Migration Plan
+## What Was Done (2026-04-26)
 
-### Prerequisites
-- Render account created
-- Payment method added (Starter plan, $7/month)
+### Phase 1: Branding Cleanup (commit `d52dcf1`)
+- Set `hideTopBar = true` in `.streamlit/config.toml`
+- Injected CSS in `app.py` to hide `#MainMenu` and `footer`
+- Verified locally with `streamlit run app.py` — no Streamlit branding visible on page
 
-### Step 1: Create Render Web Service
-- Connect GitHub repo (`gness1804/receipt-ranger`)
-- Select "Docker" as the build environment (Render will use the existing `Dockerfile`)
-- Set instance type to Starter ($7/mo, always-on)
+### Phase 2: Render Setup
+- Created Render account
+- Created Web Service connected to the `gness1804/receipt-ranger` repo
+- Set tracked branch to `deploy/upgrade-to-more-professional-hosting` (will switch to `main` after merge — see Remaining To-Dos)
+- Selected Docker runtime (Render auto-detected the existing `Dockerfile`)
+- Selected Starter plan ($7/mo, always-on)
+- Added all required environment variables in Render's dashboard:
+  - `SESSION_SECRET` — **rotated** (new Fernet key, not the SCC value)
+  - `OWNER_OPENAI_API_KEY`
+  - `OWNER_ANTHROPIC_API_KEY`
+  - `ENABLE_GOOGLE_SHEETS=true`
+  - `GOOGLE_SHEETS_CREDENTIALS` (base64-encoded service account JSON, same as SCC)
 
-### Step 2: Configure Environment Variables
-Set these in Render's service environment variables:
+### Phase 3: First Deploy + Bug Fix (commit `74ac66a`)
+- First Render build failed with `ModuleNotFoundError: No module named 'validation'`
+- Cause: Dockerfile only copied `app.py`, `main.py`, `session.py`, `sheets.py`, `pyproject.toml`, and `baml_client/` — but `validation/` (used by `main.py` for prompt injection detection) was missing
+- Fix: Added `COPY validation/ validation/` to the Dockerfile
+- Deploy succeeded after pushing the fix
 
-| Variable | Value | Notes |
-|---|---|---|
-| `SESSION_SECRET` | (from current SCC secrets) | Mark as secret |
-| `OWNER_OPENAI_API_KEY` | (from current SCC secrets) | Mark as secret |
-| `OWNER_ANTHROPIC_API_KEY` | (from current SCC secrets) | Mark as secret |
-| `ENABLE_GOOGLE_SHEETS` | `true` | |
-| `GOOGLE_SHEETS_CREDENTIALS` | (base64-encoded service_account.json) | Mark as secret |
+### Phase 4: Functional Verification
+On `https://receipt-ranger-xcjm.onrender.com/`:
+- Visual / branding check: passed (no Fork button, GitHub icon, avatar, footer, or hamburger menu)
+- WebSocket connectivity: passed (UI fully interactive, no "connecting..." spinner)
+- Receipt upload + processing: passed
+- Google Sheets integration: passed (owner detection working)
+- Idle reliability spot-check: passed (no wake-up state after 5 min idle)
 
-### Step 3: Verify Deployment
-- Confirm the app loads on the Render-provided `*.onrender.com` URL
-- Test WebSocket connectivity (app should be fully interactive, no "connecting..." issues)
-- Test receipt upload + processing end-to-end
-- Test Google Sheets integration
-- Verify no Render branding appears on the page
+### Phase 5: DNS Cutover
+- Added `receipt-ranger.com` and `www.receipt-ranger.com` to Render's custom domains
+- In Cloudflare:
+  - Edited the existing A record for the apex (was `192.0.2.1`, the placeholder for the SCC redirect): changed to **CNAME** pointing to `receipt-ranger-xcjm.onrender.com`, set to **DNS only** (grey cloud)
+  - Edited the existing CNAME for `www`: changed target to `receipt-ranger-xcjm.onrender.com`, set to **DNS only** (grey cloud)
+  - Cloudflare's CNAME flattening at apex worked fine — no need to use Render's `216.24.57.1` A-record fallback
+- Render verified DNS and issued Let's Encrypt SSL certs
+- Verified `https://receipt-ranger.com` and `https://www.receipt-ranger.com` both serve the app from Render (confirmed via `curl -I` showing `x-render-origin-server: TornadoServer/6.5.5`)
 
-### Step 4: Update DNS (Cloudflare)
-- Add custom domain in Render dashboard
-- In Cloudflare, update the CNAME for `receipt-ranger.com` to point to the Render service URL
-- **Set Cloudflare proxy to DNS-only (grey cloud)** — Render handles its own SSL; orange cloud will conflict
-- Verify SSL works on `receipt-ranger.com`
+### Phase 6: Cleanup of Old SCC Redirect
+- Deleted the "Route to Streamlit site" redirect rule in Cloudflare → Rules → Redirect Rules
+- Browser cache of the old 301 redirect was a temporary issue — fixed by testing in incognito or hard-refresh
 
-### Step 5: Hide Remaining Streamlit Branding
-The Streamlit hamburger menu and "Made with Streamlit" footer still appear in any Streamlit deployment. To remove them:
-
-1. In `.streamlit/config.toml`, add:
-   ```toml
-   [ui]
-   hideTopBar = true
-   ```
-
-2. In `app.py`, add CSS to hide the footer:
-   ```python
-   st.markdown("""<style>footer {visibility: hidden;}</style>""", unsafe_allow_html=True)
-   ```
-
-### Step 6: Decommission SCC
-- Remove the app from Streamlit Community Cloud dashboard
-- Remove any SCC-specific configuration that is no longer needed
-
-### Step 7: Update Documentation
-- Update `README.md` with new deployment info
-- Update the CLAUDE.md project instructions (deployment section references SCC)
-- Update agent memory with new deployment status
+### Phase 7: Documentation Updates (commit `0ead38d`)
+- Updated `README.md` Deployment section to describe Render setup
+- Updated `CLAUDE.md` to add Deployment section with Render details and BAML pinning constraint; dropped stale "MVP, backend only" framing
+- Updated agent memory (`MEMORY.md`) to reflect Render as current deployment with key lessons learned
 
 ---
 
-## Known Considerations
+## Key Lessons Learned
 
-- **BAML version pinning:** `baml-py==0.218.0` must remain exact in `requirements.txt`. Render builds from the Dockerfile, which uses `requirements.txt`, so this works as-is.
-- **Cloudflare DNS-only:** Same lesson from SCC — Render handles SSL, so Cloudflare must be grey cloud (DNS-only) to avoid certificate conflicts.
-- **Ephemeral filesystem:** Render's filesystem resets on each deploy/restart. Receipt images are processed in-memory and not stored locally, so this is not an issue.
+- **Dockerfile must `COPY` ALL local Python modules used at runtime.** Easy to miss — the `validation/` directory was an oversight that wasn't caught until Render's first build.
+- **301 redirects get cached aggressively by browsers.** After DNS cutover, the user's normal browser still sent them to Streamlit because the old 301 was cached. Incognito works immediately; normal browsers may need cache clearing or hard refresh.
+- **Cloudflare CNAME flattening at apex works fine with Render** — no need to use the A-record + IP fallback that Render suggests.
+- **Render does NOT auto-switch tracked branches** — when merging the deploy branch into `main`, you must manually update the tracked branch in Render's Settings → Build & Deploy.
+- **CFS pre-commit sync may report `content_conflict`** for handoff docs paired with GitHub issues. Doesn't block commits; resolve in interactive shell with `cfs gh sync` if needed.
+
+---
+
+## Remaining To-Dos
+
+These are not blocking and can be done at the user's pace.
+
+### High Priority
+
+1. **Push the doc commits** — `git push` to get the README/CLAUDE.md updates onto the remote.
+2. **Open a PR** from `deploy/upgrade-to-more-professional-hosting` → `main` and merge.
+3. **Update Render's tracked branch** — in Render → Settings → Build & Deploy, change the branch from `deploy/upgrade-to-more-professional-hosting` to `main`. This is **manual** — Render does not auto-switch when you merge. Do this **before** deleting the feature branch.
+4. **Decommission SCC** — once Render has been stable for a day or two, remove the app from the Streamlit Community Cloud dashboard. Also remove any SCC-specific config that is no longer needed (e.g., references to Streamlit secrets in any docs that aren't already updated).
+5. **Bump version** — per house rules, this migration is a significant refactor; run `bump2version minor` on a fresh commit after merging.
+
+### Low Priority / Polish
+
+6. **Replace Streamlit's default favicon.** The deployed app still serves Streamlit's default flame favicon at `./favicon.png` (a static asset baked into the Streamlit Python package). The `page_icon="🧾"` in `st.set_page_config()` only swaps it dynamically via JS, so the browser briefly shows the flame and may cache it. Fix: add a custom 32x32 PNG to the repo (e.g., `assets/favicon.png`) and overwrite Streamlit's default in the Dockerfile:
+   ```dockerfile
+   COPY assets/favicon.png /usr/local/lib/python3.11/site-packages/streamlit/static/favicon.png
+   ```
+   Skipped during the migration to avoid scope creep and unintended side effects.
+
+7. **Optional: clean up `deploy/` directory.** It contains historical EC2 + nginx artifacts (`nginx.conf`, `receipt-ranger.service`, `README.md`, a Medium PDF) that are now obsolete. Either delete or move to an `archive/` folder. README.md already labels these as historical.
+
+---
+
+## Known Considerations (carryover from research)
+
+- **BAML version pinning:** `baml-py==0.218.0` must remain exact in `requirements.txt`. BAML enforces an exact match between the runtime and the generator that produced `baml_client/`. A `>=` pin will silently break in fresh Docker builds.
+- **Cloudflare DNS-only:** Render handles its own SSL via Let's Encrypt — Cloudflare proxy (orange cloud) will break SSL/WebSockets.
+- **Ephemeral filesystem:** Render's filesystem resets on each deploy/restart. Receipt images are processed in-memory, so this is not an issue for this app.
 - **Port:** The Dockerfile exposes 8501. Render auto-detects this from the `EXPOSE` directive.

--- a/.cursor/progress/10-render-migration-handoff.md
+++ b/.cursor/progress/10-render-migration-handoff.md
@@ -1,0 +1,125 @@
+---
+github_issue: 60
+---
+# Handoff: Migration from Streamlit Community Cloud to Render
+
+**Date:** 2026-04-25
+**GitHub Issue:** #60
+**Status:** Research complete, implementation not started
+
+---
+
+## Background
+
+Receipt Ranger is currently deployed on Streamlit Community Cloud (SCC). SCC has several issues that make the app look unprofessional:
+
+- Cold starts / "wake up" screen when the app hasn't been visited recently
+- "Fork" button and GitHub icon in the top-right corner linking to source code
+- User profile avatar in the bottom-right corner
+- "Made with Streamlit" branding
+
+The goal is to move to a professional deployment that eliminates all of these while keeping Streamlit as the framework.
+
+---
+
+## Research Summary
+
+Seven platforms were evaluated. The hard constraint is **WebSocket support** — Streamlit requires persistent WebSocket connections via `/_stcore/stream`. Without this, the app does not function (this is why AWS App Runner failed previously).
+
+### Platforms Evaluated
+
+| Platform | WebSocket | Always-On Cost | Complexity | Verdict |
+|---|---|---|---|---|
+| **Render** | YES | $7/mo (Starter) | LOW | **RECOMMENDED** |
+| **Railway** | YES | $5-10/mo | VERY LOW | Strong alternative |
+| **AWS EC2** | YES (nginx) | $10-14/mo | MEDIUM | Viable but high ops burden |
+| **AWS ECS Fargate** | YES (ALB) | $20-22/mo | HIGH | ALB cost alone exceeds Render |
+| **Google Cloud Run** | YES* | $0-50/mo | LOW-MEDIUM | 60-min WebSocket timeout; always-on = ~$50/mo |
+| **Azure Container Apps** | YES | $0-50/mo | MEDIUM-HIGH | No advantage over Cloud Run |
+| **DigitalOcean App Platform** | YES | $5-12/mo | LOW | 512MB RAM may be tight on $5 plan |
+
+### Why Render Won
+
+1. **Full WebSocket support**, explicitly documented — no edge cases
+2. **$7/month Starter plan is always-on** — no cold starts, no wake-up screen
+3. **Deploys directly from existing Dockerfile** — minimal migration effort
+4. **Zero infrastructure to manage** — no VPC, ALB, IAM, nginx, or cert renewals
+5. **Custom domain + SSL** — works with Cloudflare (DNS-only / grey cloud for CNAME)
+6. **No third-party branding** — no Render icons, no GitHub links, no avatars injected into the page
+7. **Ephemeral filesystem is not a problem** — receipts are processed in-memory, not stored between sessions
+
+### Why Not the Others
+
+- **Railway:** Very close second. Slightly cheaper but WebSocket support is less explicitly documented, and HTTP/2 edge cases have been reported.
+- **EC2:** Works but you own all ops permanently (patching, nginx, Docker, Certbot). Already tried and terminated once.
+- **Fargate:** ALB minimum fee (~$16-18/mo) alone exceeds total Render cost. Massive infrastructure complexity.
+- **Cloud Run:** 60-minute WebSocket timeout disconnects users who leave tabs open. Always-on pricing (~$50/mo) is prohibitive.
+
+---
+
+## Migration Plan
+
+### Prerequisites
+- Render account created
+- Payment method added (Starter plan, $7/month)
+
+### Step 1: Create Render Web Service
+- Connect GitHub repo (`gness1804/receipt-ranger`)
+- Select "Docker" as the build environment (Render will use the existing `Dockerfile`)
+- Set instance type to Starter ($7/mo, always-on)
+
+### Step 2: Configure Environment Variables
+Set these in Render's service environment variables:
+
+| Variable | Value | Notes |
+|---|---|---|
+| `SESSION_SECRET` | (from current SCC secrets) | Mark as secret |
+| `OWNER_OPENAI_API_KEY` | (from current SCC secrets) | Mark as secret |
+| `OWNER_ANTHROPIC_API_KEY` | (from current SCC secrets) | Mark as secret |
+| `ENABLE_GOOGLE_SHEETS` | `true` | |
+| `GOOGLE_SHEETS_CREDENTIALS` | (base64-encoded service_account.json) | Mark as secret |
+
+### Step 3: Verify Deployment
+- Confirm the app loads on the Render-provided `*.onrender.com` URL
+- Test WebSocket connectivity (app should be fully interactive, no "connecting..." issues)
+- Test receipt upload + processing end-to-end
+- Test Google Sheets integration
+- Verify no Render branding appears on the page
+
+### Step 4: Update DNS (Cloudflare)
+- Add custom domain in Render dashboard
+- In Cloudflare, update the CNAME for `receipt-ranger.com` to point to the Render service URL
+- **Set Cloudflare proxy to DNS-only (grey cloud)** — Render handles its own SSL; orange cloud will conflict
+- Verify SSL works on `receipt-ranger.com`
+
+### Step 5: Hide Remaining Streamlit Branding
+The Streamlit hamburger menu and "Made with Streamlit" footer still appear in any Streamlit deployment. To remove them:
+
+1. In `.streamlit/config.toml`, add:
+   ```toml
+   [ui]
+   hideTopBar = true
+   ```
+
+2. In `app.py`, add CSS to hide the footer:
+   ```python
+   st.markdown("""<style>footer {visibility: hidden;}</style>""", unsafe_allow_html=True)
+   ```
+
+### Step 6: Decommission SCC
+- Remove the app from Streamlit Community Cloud dashboard
+- Remove any SCC-specific configuration that is no longer needed
+
+### Step 7: Update Documentation
+- Update `README.md` with new deployment info
+- Update the CLAUDE.md project instructions (deployment section references SCC)
+- Update agent memory with new deployment status
+
+---
+
+## Known Considerations
+
+- **BAML version pinning:** `baml-py==0.218.0` must remain exact in `requirements.txt`. Render builds from the Dockerfile, which uses `requirements.txt`, so this works as-is.
+- **Cloudflare DNS-only:** Same lesson from SCC — Render handles SSL, so Cloudflare must be grey cloud (DNS-only) to avoid certificate conflicts.
+- **Ephemeral filesystem:** Render's filesystem resets on each deploy/restart. Receipt images are processed in-memory and not stored locally, so this is not an issue.
+- **Port:** The Dockerfile exposes 8501. Render auto-detects this from the `EXPOSE` directive.

--- a/.cursor/refactors/3-DONE-use-a-more-professional-deployment-solution.md
+++ b/.cursor/refactors/3-DONE-use-a-more-professional-deployment-solution.md
@@ -14,3 +14,5 @@ Streamlit Community Cloud (SCC) is great for amateurs playing with applications,
 A major pain point in the past has been deploying with Streamlit, however. I do not want to change the whole application to use a different technology than Streamlit. I want to keep Streamlit but not use the Streamlit Community Cloud.  We need to find the right solution, maybe on AWS, that works with Streamlit and this application. Before doing any actual work, we will need to invoke a sub-agent to research different options and to do this rigorously with full knowledge of how the application works. 
 
 ## Acceptance criteria
+
+<!-- DONE -->

--- a/.cursor/refactors/4-make-the-outputs-more-relevant-for-the-average-user.md
+++ b/.cursor/refactors/4-make-the-outputs-more-relevant-for-the-average-user.md
@@ -1,0 +1,32 @@
+---
+github_issue: 65
+---
+# Make the outputs more relevant for the average user.
+
+## Working directory
+
+`~/Desktop/receipt-ranger`
+
+## Contents
+
+Right now, the Google Sheets option is only available for the Owner API key. (Verify this.) 
+
+The other outputs aside from Google Sheets updates are:
+- a table with the associated receipt data printed out in the application after it successfully processes a receipt
+- TSV and CSV files
+
+I would like to make this application more user-friendly to an average user who might actually want to use it. For example, I might output data in the following type of format as well as a table: 
+
+Receipt 1:
+Amount: $9.33
+Date: 4/29/26
+Vendor: McDonald's
+Category: Food & Restaurants
+
+Receipt 2:
+...
+
+I would like for a regular user to get real value out of this application, even if they don't use Google Sheets. We need to come up with ways to output information from user-submitted receipts to better achieve this. 
+
+
+## Acceptance criteria

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -29,8 +29,8 @@ enableStaticServing = false
 gatherUsageStats = false
 
 [ui]
-# Hide the deploy button
-hideTopBar = false
+# Hide the deploy button and Streamlit top bar branding
+hideTopBar = true
 
 [theme]
 # Use a green primary color instead of red (green = action/go)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,23 @@ Project-specific instructions for AI agents working on this codebase.
 
 ## Project Overview
 
-Receipt Ranger is a backend receipt scanning application. It processes receipt images through an LLM (via BAML) to extract structured data, then outputs JSON and Google Sheets-compatible TSV tables.
+Receipt Ranger processes receipt images through an LLM (via BAML) to extract structured data and outputs JSON and Google Sheets-compatible TSV tables. It has both a CLI (`main.py`) and a Streamlit web interface (`app.py`).
 
-Current status: **MVP** (backend only, no frontend).
+## Deployment
+
+The app is deployed on **Render** at https://receipt-ranger.com.
+
+- Platform: Render Web Service (Starter plan, always-on, $7/mo)
+- Build: Docker, from the repo's `Dockerfile`
+- Auto-deploys from `main`
+- DNS: Cloudflare CNAMEs (apex + www) → Render, both **DNS only** (grey cloud — Render handles SSL itself; orange cloud breaks SSL/WebSockets)
+- Streamlit branding (top bar, footer, hamburger menu) is hidden via `.streamlit/config.toml` (`hideTopBar = true`, `toolbarMode = "minimal"`) and CSS injection in `app.py`
+
+Required environment variables in Render: `SESSION_SECRET`, `OWNER_OPENAI_API_KEY`, `OWNER_ANTHROPIC_API_KEY`, `ENABLE_GOOGLE_SHEETS`, `GOOGLE_SHEETS_CREDENTIALS` (base64-encoded service account JSON).
+
+**Important constraint:** `baml-py` must be pinned to an exact version in `requirements.txt` (e.g. `baml-py==0.218.0`). BAML enforces an exact match between the runtime and the generator that produced `baml_client/` — `>=` will break in CI/Docker builds.
+
+**Historical:** Previous deployments on AWS EC2 (terminated) and Streamlit Community Cloud (decommissioned in favor of Render). AWS App Runner was attempted but does not support WebSockets, which Streamlit requires.
 
 ## Project Structure
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ COPY pyproject.toml .
 # Copy auto-generated BAML client (do not edit manually)
 COPY baml_client/ baml_client/
 
+# Copy validation module (prompt injection detection / sanitization)
+COPY validation/ validation/
+
 # Copy Streamlit configuration
 COPY .streamlit/ .streamlit/
 

--- a/README.md
+++ b/README.md
@@ -196,17 +196,32 @@ If there are new receipts in the `data/receipts` folder, they will be processed 
 
 ## Deployment
 
-Receipt Ranger can be deployed to AWS EC2 for access from any device (including mobile). See [`deploy/README.md`](deploy/README.md) for a comprehensive guide covering:
+Receipt Ranger is deployed on [Render](https://render.com) at https://receipt-ranger.com.
 
-- AWS EC2 instance setup
-- Nginx reverse proxy configuration
-- CloudFlare DNS and SSL setup
-- Security hardening (firewall, fail2ban)
-- Auto-restart with systemd
+### How It's Deployed
 
-The deployed app uses a "bring your own API key" model - users enter their OpenAI/Anthropic keys via the web interface. Keys are Fernet-encrypted immediately on entry and stored only as an opaque token for the duration of the session.
+- **Platform:** Render Web Service (Starter plan, always-on)
+- **Build:** Docker, using the `Dockerfile` in the repo root
+- **Branch:** auto-deploys from `main`
+- **DNS:** Cloudflare CNAMEs for both `receipt-ranger.com` (apex) and `www.receipt-ranger.com` point to the Render service. Both records are set to **DNS only** (grey cloud) — Render manages its own SSL via Let's Encrypt, and Cloudflare's proxy conflicts with it.
 
-Set a stable `SESSION_SECRET` in your environment for production (see Setup below).
+### Environment Variables (set in Render's dashboard)
+
+| Variable | Purpose |
+|---|---|
+| `SESSION_SECRET` | Fernet key for encrypting user API keys at rest |
+| `OWNER_OPENAI_API_KEY` | Owner's OpenAI key (used for owner-only features like Sheets integration) |
+| `OWNER_ANTHROPIC_API_KEY` | Owner's Anthropic key (same purpose) |
+| `ENABLE_GOOGLE_SHEETS` | `true` to enable Sheets export |
+| `GOOGLE_SHEETS_CREDENTIALS` | Base64-encoded service account JSON for Google Sheets |
+
+### App Behavior
+
+The deployed app uses a "bring your own API key" model — users enter their OpenAI/Anthropic keys via the web interface. Keys are Fernet-encrypted immediately on entry and stored only as an opaque token for the session.
+
+### Historical Deployment Notes
+
+The repo previously contained EC2 + nginx setup files in `deploy/` (now historical). A migration to AWS App Runner was attempted but failed because App Runner does not support WebSocket connections, which Streamlit requires.
 
 ## Documentation
 

--- a/app.py
+++ b/app.py
@@ -880,7 +880,7 @@ def main_app():
 
     # Footer
     st.divider()
-    st.caption("Receipt Ranger v0.9.6 | Process receipt images with AI")
+    st.caption("Receipt Ranger v0.10.0 | Process receipt images with AI")
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -19,6 +19,16 @@ st.set_page_config(
     initial_sidebar_state="collapsed",
 )
 
+st.markdown(
+    """
+    <style>
+    #MainMenu {visibility: hidden;}
+    footer {visibility: hidden;}
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
 # Sync Streamlit Cloud secrets into os.environ so all modules that use
 # os.environ.get() work in both local (.env) and Streamlit Cloud (st.secrets)
 # contexts without modification.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "receipt-ranger"
-version = "0.9.6"
+version = "0.10.0"
 description = "Receipt scanner that extracts structured data from receipt images using BAML and LLMs"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This is a significant refactor that re-deploys the website from Streamlit Community Cloud to Render. This was done because SCC had some cheesy features that made the app look amateurish. Namely, if the app hadn't been used for a period of time, there was a wake-up state where the user had to manually click to wake up the app and then saw a corny animation while this happened. Also, there was SCC-related branding on various parts of the deployed app, which made it look like a student app rather than a real professional app. This migration solves this problem. 

- **docs: add handoff document for Render migration (issue #60)**
- **Add more expansive permissions to Claude local settings to try to reduce prompt frequency.**
- **chore: hide Streamlit branding for Render deployment (issue #60)**
- **fix: copy validation/ directory in Dockerfile (issue #60)**
- **docs: update README and CLAUDE.md for Render deployment (issue #60)**
- **docs: update Render migration handoff with completion status (issue #60)**
- **Local Claude Changes**
- **chore: cfs docs**
- **Bump version: 0.9.6 → 0.10.0**
- **chore: mark Render migration handoff as DONE (issue #60)**
- **chore: mark refactors/3 CFS doc as DONE (issue #60)**
