### PR TITLE
chore/post render cleanup

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"8fe5f388-3c2c-457a-b638-4422b65970d5","pid":8289,"procStart":"Sun Apr 26 19:12:29 2026","acquiredAt":1777231114331}

--- a/.cursor/bugs/14-four-google-sheets-tests-failing-on-main.md
+++ b/.cursor/bugs/14-four-google-sheets-tests-failing-on-main.md
@@ -1,0 +1,41 @@
+---
+github_issue: 68
+---
+# Four Google Sheets tests failing on main
+
+## Working directory
+
+`~/Desktop/receipt-ranger`
+
+## Contents
+
+Four tests in `tests/test_app.py` have been failing on `main` for a while (predate the Render migration; surfaced again during post-migration cleanup on 2026-04-29). The full pytest run shows 151 passing and 4 failing, all in Google Sheets / service account mocking territory:
+
+- `tests/test_app.py::TestCheckGoogleSheetsSetup::test_missing_service_account_file` (line 194)
+- `tests/test_app.py::TestUploadToGoogleSheets::test_skips_existing_receipts` (line 376)
+- `tests/test_app.py::TestSheetsIntegration::test_get_all_existing_receipts` (line 561)
+- `tests/test_app.py::TestSheetsIntegration::test_check_receipts_for_duplicates` (line 580)
+
+### Why they appear to be failing
+
+These look like stale tests left behind after a refactor of the sheets / credentials code, not real bugs in the app:
+
+1. **`test_missing_service_account_file`** patches `sheets.os.path.exists` to return `False` and expects `check_google_sheets_setup()` to return `(False, "...not found...")`. The function appears to have been refactored to resolve credentials from env var first and fall back to the file (per the agent memory note: "Don't pre-check for service_account.json before calling get_gspread_client() — let the function handle credential resolution (env var first, then file)"). The pre-existence check the test mocks is no longer the path the function takes, so the function returns success regardless of the patched `os.path.exists`.
+
+2. **`test_check_receipts_for_duplicates`** patches `sheets.get_all_existing_receipts` to return a one-item set, then calls `check_receipts_for_duplicates(mock_client, receipts)` and expects 1 duplicate. It returns 0, suggesting either the function's call signature/lookup strategy changed, or the patched function is no longer the one actually called.
+
+3. The two `TestUploadToGoogleSheets::test_skips_existing_receipts` and `TestSheetsIntegration::test_get_all_existing_receipts` failures likely share the same root cause as 1 and 2 (drifted mocks vs current implementation).
+
+A side note: at least one failure also surfaces an `AssertionError` deep inside the `dotenv` library's frame-walking code (`dotenv/main.py:309`), which suggests `load_dotenv()` is being called inside the function under test in a context where pytest's frame layout doesn't match what `dotenv` expects. This may be a separate dotenv/pytest interaction worth understanding, or just a downstream effect of the mocking issue.
+
+### App-level impact
+
+None observed. The application works correctly in production on Render. These are test-suite hygiene issues only — but they cause `pytest` to report 4 failures every run, which is noisy and erodes trust in the suite.
+
+## Acceptance criteria
+
+- All 4 failing tests pass on a clean `main` checkout
+- Fix should update tests to match current implementation (preferred), not change app behavior just to satisfy the tests
+- If a test is found to be testing a code path that no longer exists, the test should be deleted rather than rewritten to test something else
+- Confirm no other tests regress as a result of the changes
+- Note in the PR description what each test was actually testing before vs after, so future readers understand the drift

--- a/.cursor/refactors/5-remove-ec2-and-nginx-artifacts.md
+++ b/.cursor/refactors/5-remove-ec2-and-nginx-artifacts.md
@@ -1,0 +1,31 @@
+---
+github_issue: 67
+---
+# Remove leftover EC2/nginx deployment artifacts
+
+## Working directory
+
+`~/Desktop/receipt-ranger`
+
+## Contents
+
+The repo still contains files from the previous AWS EC2 + nginx deployment, which is no longer in use. The application now runs on Render (see `.cursor/progress/10-DONE-render-migration-handoff.md`), and the EC2 instance has been terminated.
+
+The leftover artifacts include:
+
+- `deploy.sh` at the repo root — a Bash script that previously handled EC2 deploys
+- `deploy/` directory — nginx config and other EC2-era setup files
+- A historical mention in `README.md` (around line 224) referencing these files
+
+None of these are referenced by the current Render-based deployment (`Dockerfile`, `.streamlit/config.toml`, env vars in Render dashboard).
+
+We should remove these so the repo no longer carries dead deployment infrastructure. Anyone returning to this codebase later (or scanning for unused code) will find it cleaner without the historical EC2 baggage. If we ever need to reference the EC2 setup again, it remains accessible in git history and on the `feature/aws-deployment` branch.
+
+## Acceptance criteria
+
+- `deploy.sh` deleted from repo root
+- `deploy/` directory deleted
+- `README.md` historical mention of EC2/nginx (around the "deployment" section) removed or simplified to a single sentence pointing at git history
+- All tests still pass
+- No remaining references to `deploy.sh` or the `deploy/` directory in the codebase (verify with `grep`)
+- Confirm the App Runner-related branch (`refactor/ec2-to-app-runner`) and `feature/aws-deployment` branch are preserved if anyone needs to refer back; do not delete those branches as part of this work

--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,9 @@ data/exclusion_criteria.txt
 data/receipts/
 service_account.json
 
+# Claude Code runtime artifacts
+.claude/*.lock
+
 # Ruff stuff:
 .ruff_cache/
 

--- a/app.py
+++ b/app.py
@@ -29,16 +29,6 @@ st.markdown(
     unsafe_allow_html=True,
 )
 
-# Sync Streamlit Cloud secrets into os.environ so all modules that use
-# os.environ.get() work in both local (.env) and Streamlit Cloud (st.secrets)
-# contexts without modification.
-try:
-    for _k, _v in st.secrets.items():
-        if isinstance(_v, str):
-            os.environ.setdefault(_k, _v)
-except Exception:
-    pass
-
 import main  # noqa: E402
 from main import (  # noqa: E402
     MIME_TYPES,


### PR DESCRIPTION
Assorted post-render cleanups, including some housekeeping items and removing some dead Streamlit Cloud code.

- **chore: remove dead Streamlit Cloud secrets sync from app.py**
- **chore: ignore .claude lock files and untrack existing one**
- **docs: add CFS docs for EC2/nginx cleanup and failing Sheets tests**
