### PR TITLE
bug/api key hash not persisting

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.0
+current_version = 0.11.1
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/.cursor/bugs/15-DONE-app-does-not-save-api-key.md
+++ b/.cursor/bugs/15-DONE-app-does-not-save-api-key.md
@@ -1,0 +1,19 @@
+---
+github_issue: 72
+---
+# App does not save API key
+
+## Working directory
+
+`~/Desktop/receipt-ranger`
+
+## Contents
+
+When I enter in an API key successfully and then enter a receipt and process it, the application works as expected. But if I then refresh the page, it asks for an API key again. The application is supposed to save a hash of the API key in local storage. This worked until recently. Now, when I use the application, the local key saving no longer works. We need to fix this. 
+
+
+## Acceptance criteria
+
+- [ ] When the application has successfully received an API key and then you refresh the page or return to the application later, the API key should still be saved.
+
+<!-- DONE -->

--- a/app.py
+++ b/app.py
@@ -98,6 +98,10 @@ def init_session_state():
         st.session_state.api_key_token = ""
     if "api_key_clear_pending" not in st.session_state:
         st.session_state.api_key_clear_pending = False
+    if "api_key_save_pending_token" not in st.session_state:
+        st.session_state.api_key_save_pending_token = None
+    if "api_key_save_pending_provider" not in st.session_state:
+        st.session_state.api_key_save_pending_provider = None
     if "api_provider" not in st.session_state:
         st.session_state.api_provider = "OpenAI"
 
@@ -435,9 +439,15 @@ def render_sidebar(cookie=None) -> bool:
                 if api_key:
                     token = encrypt_api_key(api_key)
                     st.session_state.api_key_token = token
+                    # Defer cookie.set to the next render. Calling cookie.set
+                    # immediately followed by st.rerun() in the same script
+                    # run aborts before the cookie-controller iframe can
+                    # execute document.cookie = ... on the frontend, so the
+                    # browser cookie never gets written and the key fails to
+                    # persist across refreshes.
                     if cookie is not None:
-                        cookie.set("rr_session", token, max_age=7 * 24 * 60 * 60)
-                        cookie.set("rr_provider", provider, max_age=7 * 24 * 60 * 60)
+                        st.session_state.api_key_save_pending_token = token
+                        st.session_state.api_key_save_pending_provider = provider
                     st.rerun()
 
         # Google Sheets status — owner only
@@ -855,7 +865,20 @@ def main_app():
         cookie.remove("rr_provider")
         st.session_state.api_key_clear_pending = False
 
-    if not clear_pending:
+    # Deferred cookie save: the API-key input handler sets these flags and
+    # reruns so that cookie.set() runs here (in a script that completes
+    # without a trailing st.rerun()), letting the iframe actually write
+    # document.cookie before being torn down.
+    save_token = st.session_state.api_key_save_pending_token
+    save_provider = st.session_state.api_key_save_pending_provider
+    if save_token:
+        cookie.set("rr_session", save_token, max_age=7 * 24 * 60 * 60)
+        if save_provider:
+            cookie.set("rr_provider", save_provider, max_age=7 * 24 * 60 * 60)
+        st.session_state.api_key_save_pending_token = None
+        st.session_state.api_key_save_pending_provider = None
+
+    if not clear_pending and not save_token:
         _load_cookie_to_session(cookie)
 
     sheets_available = render_sidebar(cookie)

--- a/app.py
+++ b/app.py
@@ -426,6 +426,11 @@ def render_sidebar(cookie=None) -> bool:
                 st.success(f"Key configured · `{masked}`")
                 if st.button("Change API key", key="change_api_key_btn"):
                     st.session_state.api_key_token = ""
+                    # Drop any in-flight deferred save so the cookie can't be
+                    # re-written on the next render after the user just asked
+                    # to clear it.
+                    st.session_state.api_key_save_pending_token = None
+                    st.session_state.api_key_save_pending_provider = None
                     if cookie is not None:
                         st.session_state.api_key_clear_pending = True
                     st.rerun()
@@ -872,9 +877,17 @@ def main_app():
     save_token = st.session_state.api_key_save_pending_token
     save_provider = st.session_state.api_key_save_pending_provider
     if save_token:
-        cookie.set("rr_session", save_token, max_age=7 * 24 * 60 * 60)
+        # secure=True keeps the cookie HTTPS-only on production
+        # (receipt-ranger.com is HTTPS via Render). Browsers exempt localhost
+        # from the Secure requirement, so local dev still works.
+        cookie.set("rr_session", save_token, max_age=7 * 24 * 60 * 60, secure=True)
         if save_provider:
-            cookie.set("rr_provider", save_provider, max_age=7 * 24 * 60 * 60)
+            cookie.set(
+                "rr_provider",
+                save_provider,
+                max_age=7 * 24 * 60 * 60,
+                secure=True,
+            )
         st.session_state.api_key_save_pending_token = None
         st.session_state.api_key_save_pending_provider = None
 

--- a/app.py
+++ b/app.py
@@ -914,7 +914,7 @@ def main_app():
     st.markdown(
         (
             '<div class="gn-footer">'
-            'Receipt Ranger · <span class="version">v0.11.0</span> · '
+            'Receipt Ranger · <span class="version">v0.11.1</span> · '
             "Structured data from receipt images."
             "</div>"
         ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "receipt-ranger"
-version = "0.11.0"
+version = "0.11.1"
 description = "Receipt scanner that extracts structured data from receipt images using BAML and LLMs"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -50,6 +50,44 @@ class TestSession:
         assert plaintext not in token
 
 
+class TestApiKeyDeferredCookieSave:
+    """Regression tests for issue #72: API key cookie not persisting.
+
+    The cookie-controller iframe needs the current script run to complete
+    so it can write document.cookie. Calling cookie.set() and then
+    st.rerun() in the same run aborts before the iframe flushes, so saves
+    have to be deferred to the next render.
+    """
+
+    def test_init_session_state_seeds_deferred_save_keys(self):
+        """init_session_state must set both deferred-save keys to None.
+
+        Without these defaults, the main_app deferred-save branch raises
+        AttributeError on first render.
+        """
+
+        class FakeSessionState(dict):
+            def __getattr__(self, k):
+                if k in self:
+                    return self[k]
+                raise AttributeError(k)
+
+            def __setattr__(self, k, v):
+                self[k] = v
+
+        fake = FakeSessionState()
+        with patch("app.st") as mock_st:
+            mock_st.session_state = fake
+            from app import init_session_state
+
+            init_session_state()
+
+        assert fake["api_key_save_pending_token"] is None
+        assert fake["api_key_save_pending_provider"] is None
+        assert fake["api_key_token"] == ""
+        assert fake["api_key_clear_pending"] is False
+
+
 class TestGetMimeType:
     def test_jpg_extension(self):
         from app import get_mime_type


### PR DESCRIPTION
Fix bug where API key was not persisting between sessions/refresh. 

- **fix: defer API-key cookie.set so the browser cookie actually persists (issue #72)**
- **fix: harden API-key cookie save (secure flag + clear pending on revoke)**
- **Bump version: 0.11.0 → 0.11.1**
