### PR TITLE
Fix four stale Google Sheets tests in test_app.py

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,6 +5,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+# Import app at module load time so app.py's top-level load_dotenv() runs during
+# collection (in a normal frame) rather than lazily inside a test function. When
+# the first `from app import ...` happens inside a pytest test frame, dotenv's
+# find_dotenv() frame-walk hits an AssertionError; importing here avoids that.
+import app  # noqa: E402,F401
+
 # ---------------------------------------------------------------------------
 # TestSession — tests for session.py encryption helpers
 # ---------------------------------------------------------------------------
@@ -228,8 +234,12 @@ class TestSheetsAvailability:
 
 
 class TestCheckGoogleSheetsSetup:
+    @patch.dict(os.environ, {"GOOGLE_SHEETS_CREDENTIALS": ""})
     @patch("sheets.os.path.exists")
     def test_missing_service_account_file(self, mock_exists):
+        # No env-var credentials and no file on disk → setup should report failure.
+        # GOOGLE_SHEETS_CREDENTIALS is cleared so get_gspread_client() falls through
+        # to the file-existence check that this test mocks away.
         mock_exists.return_value = False
         from app import check_google_sheets_setup
 
@@ -414,8 +424,10 @@ class TestUploadToGoogleSheets:
     def test_skips_existing_receipts(self, mock_client, mock_worksheet, mock_existing):
         mock_client.return_value = MagicMock()
         mock_worksheet.return_value = MagicMock()
-        # Receipt already exists in sheets
-        mock_existing.return_value = {("01/20/2026", "25.5", "Test Store")}
+        # Receipt already exists in sheets. get_existing_receipts() normalizes
+        # dates via _format_date_for_sheets (no leading zeros), so the stored key
+        # is "1/20/2026", matching the key upload_to_google_sheets() builds.
+        mock_existing.return_value = {("1/20/2026", "25.5", "Test Store")}
 
         from app import upload_to_google_sheets
 
@@ -613,7 +625,9 @@ class TestSheetsIntegration:
         result = get_all_existing_receipts(mock_client)
 
         assert len(result) == 1
-        assert ("01/20/2026", "25.50", "Test Store") in result
+        # get_existing_receipts() normalizes the date via _format_date_for_sheets,
+        # dropping leading zeros: "01/20/2026" -> "1/20/2026".
+        assert ("1/20/2026", "25.50", "Test Store") in result
 
     def test_check_receipts_for_duplicates(self):
         from sheets import check_receipts_for_duplicates
@@ -622,7 +636,10 @@ class TestSheetsIntegration:
 
         # Patch get_all_existing_receipts within the test
         with patch("sheets.get_all_existing_receipts") as mock_existing:
-            mock_existing.return_value = {("01/20/2026", "25.5", "Test Store")}
+            # get_all_existing_receipts returns normalized dates (no leading
+            # zeros), so the stored key is "1/20/2026" — matching the key that
+            # check_receipts_for_duplicates builds from the receipt below.
+            mock_existing.return_value = {("1/20/2026", "25.5", "Test Store")}
 
             receipts = [
                 {"date": "01/20/2026", "amount": 25.5, "vendor": "Test Store"},


### PR DESCRIPTION
Fixes #68.

All four failures were **test-side drift**, not app bugs — the application behaves correctly in production and no app code was changed. The full suite now passes (156 passed, 0 failed).

## Root causes

### 1. Date-normalization drift (3 of 4 tests)

`sheets._format_date_for_sheets()` strips leading zeros (`"01/20/2026"` → `"1/20/2026"`), and `get_existing_receipts` / `get_all_existing_receipts` now run every date through it. The tests still seeded their mocks/expectations with the old leading-zero strings, so the dedup keys never matched the keys the code builds.

### 2. dotenv frame-walk artifact (`test_missing_service_account_file`)

The lazy `from app import …` inside the test triggered `app.py`'s top-level `load_dotenv()` from within a pytest test frame, blowing up in `dotenv.find_dotenv()`'s `assert frame.f_back is not None`. It only surfaced when this test ran first/in isolation (otherwise `app` was already imported/cached by an earlier test). It was also brittle to a populated `GOOGLE_SHEETS_CREDENTIALS` env var, which would short-circuit `get_gspread_client()` before the file-existence check the test mocks.

## What each test verified — before vs after

| Test | Before | After |
|------|--------|-------|
| `TestSheetsIntegration::test_get_all_existing_receipts` | Asserted result contained `("01/20/2026", "25.50", "Test Store")` | Asserts `("1/20/2026", "25.50", "Test Store")` — the normalized form the function actually produces |
| `TestSheetsIntegration::test_check_receipts_for_duplicates` | Mocked `get_all_existing_receipts` → `{("01/20/2026", …)}`; the receipt key got normalized to `1/20/2026`, so 0 duplicates were found | Mock returns `{("1/20/2026", …)}`; correctly finds 1 duplicate |
| `TestUploadToGoogleSheets::test_skips_existing_receipts` | Mocked `get_existing_receipts` → `{("01/20/2026", …)}`; upload key was normalized, didn't match, so the receipt was uploaded (count 1) | Mock returns `{("1/20/2026", …)}`; upload is correctly skipped (count 0) |
| `TestCheckGoogleSheetsSetup::test_missing_service_account_file` | Failed in isolation via the dotenv frame-walk `AssertionError`; brittle to a set `GOOGLE_SHEETS_CREDENTIALS` | Added module-level `import app` so `load_dotenv()` runs at collection in a normal frame; clears `GOOGLE_SHEETS_CREDENTIALS` so `get_gspread_client()` genuinely exercises the file-existence path the test mocks |

## Notes on acceptance criteria

- No code path was removed, so no test needed deletion — all four still exercise real, current behavior; only the fixtures/expectations were corrected to match the implementation.
- Verified each of the four passes in isolation (the harness mode that originally exposed the dotenv failure) and that the full suite has no regressions.

https://claude.ai/code/session_01YPeh49GsMQ9mCodTRqc8qa

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPeh49GsMQ9mCodTRqc8qa)_