### PR TITLE
bug/fix date handling

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.2
+current_version = 0.11.3
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/.cursor/bugs/11-DONE-application-should-retry-if-it-cant-capture-a-date.md
+++ b/.cursor/bugs/11-DONE-application-should-retry-if-it-cant-capture-a-date.md
@@ -19,3 +19,5 @@ If the application fails to capture a date for a particular receipt, either beca
 This will allow the user to only have to worry about entering in the date in Google Sheets manually, rather than having to enter in the entire recipe. If the date fails, the user will still be able to capture most of the information automatically. 
 
 ## Acceptance criteria
+
+<!-- DONE -->

--- a/.cursor/bugs/11-application-should-retry-if-it-cant-capture-a-date.md
+++ b/.cursor/bugs/11-application-should-retry-if-it-cant-capture-a-date.md
@@ -9,6 +9,13 @@ github_issue: 49
 
 ## Contents
 
-If the application can't capture a receipt date, then the date field in the resulting table is blank, and it doesn't attempt to upload a Google sheet because it doesn't know what date to upload to. If the application in the web version can't capture a date, it should offer to retry. There should be two or three retry steps before it gives up and asks you to just enter the receipt manually. 
+If the application can't capture a receipt date, then the date field in the resulting table is blank, and it doesn't attempt to upload a Google sheet because it doesn't know what date to upload to. This is a poor user experience because the user then has to enter in the entire receipt data in the Google Receipts just because a date wasn't captured, even if everything else was fine. Instead of the current behavior, I would like the following behavior. 
+
+If the application fails to capture a date for a particular receipt, either because it couldn't find the date or the date wasn't legible, then it should do the following: 
+
+- Retry once
+- If after the retry the date is still not shown, it should still upload the receipt data to Google Sheets, but to a new tab called "Unknown Date". 
+
+This will allow the user to only have to worry about entering in the date in Google Sheets manually, rather than having to enter in the entire recipe. If the date fails, the user will still be able to capture most of the information automatically. 
 
 ## Acceptance criteria

--- a/.cursor/bugs/14-DONE-four-google-sheets-tests-failing-on-main.md
+++ b/.cursor/bugs/14-DONE-four-google-sheets-tests-failing-on-main.md
@@ -39,3 +39,5 @@ None observed. The application works correctly in production on Render. These ar
 - If a test is found to be testing a code path that no longer exists, the test should be deleted rather than rewritten to test something else
 - Confirm no other tests regress as a result of the changes
 - Note in the PR description what each test was actually testing before vs after, so future readers understand the drift
+
+<!-- DONE -->

--- a/README.md
+++ b/README.md
@@ -186,6 +186,16 @@ The script will:
 - Find or create a worksheet for each month and year (e.g., "January 2026").
 - Check for duplicate receipts (based on Date, Amount, and Vendor) and only add new ones.
 
+#### Receipts with a missing date
+
+If a receipt's date can't be captured (unreadable or absent), Receipt Ranger
+retries the extraction once. If the date still can't be determined, the receipt
+is **not dropped** — it's uploaded to a dedicated **`Unknown Date`** worksheet
+with the date column left blank, so you only need to fill in the date manually
+rather than re-enter the whole receipt. Two undated receipts with the same
+amount and vendor are still deduplicated, while undated receipts never collide
+with dated ones.
+
 You can also process new receipts and upload them in the same run:
 
 ```bash

--- a/app.py
+++ b/app.py
@@ -906,7 +906,7 @@ def main_app():
     st.markdown(
         (
             '<div class="gn-footer">'
-            'Receipt Ranger · <span class="version">v0.11.2</span> · '
+            'Receipt Ranger · <span class="version">v0.11.3</span> · '
             "Structured data from receipt images."
             "</div>"
         ),

--- a/app.py
+++ b/app.py
@@ -193,11 +193,12 @@ def check_for_duplicates(receipts: list[dict]) -> list[dict]:
         return []
 
 
-def upload_to_google_sheets(receipts: list[dict]) -> tuple[int, list[str]]:
+def upload_to_google_sheets(receipts: list[dict]) -> tuple[int, list[str], list[str]]:
     """Upload receipts to Google Sheets.
 
     Returns:
-        Tuple of (count of uploaded receipts, list of error messages)
+        Tuple of (count of uploaded receipts, list of error messages,
+        list of advisory notices).
     """
     try:
         from sheets import (
@@ -208,15 +209,16 @@ def upload_to_google_sheets(receipts: list[dict]) -> tuple[int, list[str]]:
             _format_date_for_sheets,
         )
     except ImportError:
-        return 0, ["gspread library not installed"]
+        return 0, ["gspread library not installed"], []
 
     errors = []
+    notices = []
     uploaded_count = 0
 
     try:
         client = get_gspread_client()
     except Exception as e:
-        return 0, [f"Could not authenticate with Google Sheets: {str(e)}"]
+        return 0, [f"Could not authenticate with Google Sheets: {str(e)}"], []
 
     # Filter out excluded receipts
     receipts_to_upload, _ = _filter_excluded_receipts(receipts, print_warnings=False)
@@ -255,8 +257,20 @@ def upload_to_google_sheets(receipts: list[dict]) -> tuple[int, list[str]]:
                 uploaded_count += 1
             except Exception as e:
                 errors.append(f"Could not append receipt: {e}")
+        elif not normalized_date:
+            # Undated receipts dedupe on (vendor, amount) alone, so a genuinely
+            # distinct purchase can be mistaken for a duplicate. Advise the user
+            # instead of dropping it silently (issue #49).
+            vendor = receipt.get("vendor") or "Unknown vendor"
+            amount = receipt.get("amount") or 0
+            notices.append(
+                f"Skipped an undated receipt matching an existing "
+                f"'Unknown Date' entry ({vendor}, ${amount:.2f}). If this is a "
+                f"distinct purchase, add it manually — undated receipts with "
+                f"the same vendor and amount can't be told apart."
+            )
 
-    return uploaded_count, errors
+    return uploaded_count, errors, notices
 
 
 def process_receipts(files_to_process: dict, provider: str = "Anthropic") -> list[dict]:
@@ -759,12 +773,15 @@ def process_and_display_results(sheets_available: bool):
 
         if new_receipts:
             with st.spinner("Uploading to Google Sheets..."):
-                uploaded_count, errors = upload_to_google_sheets(new_receipts)
+                uploaded_count, errors, notices = upload_to_google_sheets(new_receipts)
 
             if uploaded_count > 0:
                 st.success(
                     f"Uploaded {uploaded_count} new receipt(s) to Google Sheets."
                 )
+
+            for notice in notices:
+                st.warning(notice)
 
             if errors:
                 for error in errors:

--- a/app.py
+++ b/app.py
@@ -224,20 +224,12 @@ def upload_to_google_sheets(receipts: list[dict]) -> tuple[int, list[str]]:
     worksheets = {}
 
     for receipt in receipts_to_upload:
-        date_str = receipt.get("date")
-        if not date_str:
-            continue
+        date_str = receipt.get("date") or ""
 
-        try:
-            parsed_date = main._parse_date(date_str)
-            if not parsed_date:
-                errors.append(f"Could not parse date '{date_str}'")
-                continue
-
-            worksheet_title = parsed_date.strftime("%B %Y")
-        except (ValueError, TypeError):
-            errors.append(f"Invalid date format for '{date_str}'")
-            continue
+        # Receipts with a missing/unparseable date go to the "Unknown Date"
+        # worksheet (issue #49) instead of being skipped, so the user only has
+        # to fill in the date manually rather than re-enter the whole receipt.
+        worksheet_title, normalized_date = main._resolve_worksheet_for_date(date_str)
 
         if worksheet_title not in worksheets:
             try:
@@ -251,7 +243,7 @@ def upload_to_google_sheets(receipts: list[dict]) -> tuple[int, list[str]]:
         worksheet, existing_receipts = worksheets[worksheet_title]
 
         receipt_key = (
-            _format_date_for_sheets(str(receipt.get("date"))),
+            _format_date_for_sheets(normalized_date),
             str(receipt.get("amount")),
             str(receipt.get("vendor")),
         )

--- a/main.py
+++ b/main.py
@@ -420,6 +420,47 @@ def _get_current_date_str() -> str:
     return datetime.now().strftime("%m/%d/%Y")
 
 
+# Worksheet that holds receipts whose date could not be captured (issue #49).
+UNKNOWN_DATE_WORKSHEET = "Unknown Date"
+
+
+def _resolve_worksheet_for_date(date_str: str) -> tuple[str, str]:
+    """Determine the target worksheet and normalized date for a receipt.
+
+    Receipts with a usable date go to a month worksheet (e.g. "January 2026").
+    Receipts whose date is missing or unparseable are routed to the
+    "Unknown Date" worksheet and given an empty normalized date so they dedupe
+    consistently regardless of any leftover unparseable string.
+
+    Returns:
+        Tuple of (worksheet_title, normalized_date).
+    """
+    parsed = _parse_date(date_str)
+    if not parsed:
+        return UNKNOWN_DATE_WORKSHEET, ""
+    return parsed.strftime("%B %Y"), date_str
+
+
+def _run_baml_extraction(
+    image, exclusion_criteria: str, current_date: str, provider: str
+):
+    """Call the appropriate BAML extraction function for the given provider."""
+    if provider == "OpenAI":
+        return b.ExtractReceiptFromImageOpenAI(image, exclusion_criteria, current_date)
+    return b.ExtractReceiptFromImage(image, exclusion_criteria, current_date)
+
+
+def _validate_extracted_date(date_str: str) -> str:
+    """Return the date, blanking out untrustworthy future dates."""
+    if _is_future_date(date_str):
+        print(
+            f"    WARNING: Future date detected ({date_str}), "
+            "replacing with empty string"
+        )
+        return ""
+    return date_str
+
+
 def extract_receipt(filepath: str, exclusion_criteria: str) -> dict:
     """Run BAML extraction on a receipt image and return the result as a dict."""
     _, ext = os.path.splitext(filepath)
@@ -457,13 +498,7 @@ def extract_receipt_from_bytes(
     image = baml_py.Image.from_base64(mime_type, image_data)
     current_date = _get_current_date_str()
 
-    # Use the appropriate extraction function based on provider
-    if provider == "OpenAI":
-        receipt = b.ExtractReceiptFromImageOpenAI(
-            image, exclusion_criteria, current_date
-        )
-    else:
-        receipt = b.ExtractReceiptFromImage(image, exclusion_criteria, current_date)
+    receipt = _run_baml_extraction(image, exclusion_criteria, current_date, provider)
 
     # Check if the image is a valid receipt
     if not receipt.isValidReceipt:
@@ -481,13 +516,20 @@ def extract_receipt_from_bytes(
         }
 
     # Validate the date - replace future dates with empty string
-    extracted_date = receipt.date
-    if _is_future_date(extracted_date):
-        print(
-            f"    WARNING: Future date detected ({extracted_date}), "
-            "replacing with empty string"
+    extracted_date = _validate_extracted_date(receipt.date or "")
+
+    # Retry once if the date could not be captured (issue #49). Only the date
+    # is taken from the retry; the original extraction's other fields (amount,
+    # vendor, etc.) are kept so a good first read isn't regressed.
+    if not extracted_date:
+        print("    No date captured; retrying extraction once...")
+        retry_receipt = _run_baml_extraction(
+            image, exclusion_criteria, current_date, provider
         )
-        extracted_date = ""
+        if retry_receipt.isValidReceipt:
+            retry_date = _validate_extracted_date(retry_receipt.date or "")
+            if retry_date:
+                extracted_date = retry_date
 
     return {
         "isValidReceipt": True,
@@ -661,30 +703,12 @@ def upload_to_sheets(receipts: list[dict]):
     receipts_to_upload, _ = _filter_excluded_receipts(receipts, print_warnings=False)
 
     for receipt in receipts_to_upload:
-        date_str = receipt.get("date")
-        if not date_str:
-            continue
+        date_str = receipt.get("date") or ""
 
-        try:
-            # Use the existing _parse_date function
-            parsed_date = _parse_date(date_str)
-            if not parsed_date:
-                warning_message = (
-                    f"[Sheets] WARNING: Could not parse date '{date_str}', "
-                    "skipping receipt."
-                )
-                print(warning_message)
-                continue
-
-            # Format: "January 2026"
-            worksheet_title = parsed_date.strftime("%B %Y")
-        except (ValueError, TypeError):
-            warning_message = (
-                f"[Sheets] WARNING: Invalid date format for '{date_str}', "
-                "skipping receipt."
-            )
-            print(warning_message)
-            continue
+        # Receipts with a missing/unparseable date go to the "Unknown Date"
+        # worksheet (issue #49) instead of being skipped, so the user only has
+        # to fill in the date manually rather than re-enter the whole receipt.
+        worksheet_title, normalized_date = _resolve_worksheet_for_date(date_str)
 
         if worksheet_title not in worksheets:
             print(f"[Sheets] Accessing worksheet: '{worksheet_title}'...")
@@ -702,9 +726,11 @@ def upload_to_sheets(receipts: list[dict]):
 
         worksheet, existing_receipts = worksheets[worksheet_title]
 
-        # Create a unique key for the receipt to check for duplicates
+        # Create a unique key for the receipt to check for duplicates. Use the
+        # normalized date so all "Unknown Date" receipts share an empty date
+        # token and dedupe consistently.
         receipt_key = (
-            _format_date_for_sheets(str(receipt.get("date"))),
+            _format_date_for_sheets(normalized_date),
             str(receipt.get("amount")),
             str(receipt.get("vendor")),
         )

--- a/main.py
+++ b/main.py
@@ -745,6 +745,18 @@ def upload_to_sheets(receipts: list[dict]):
                 print(f"  [Sheets] Added new receipt: {vendor} on {date}")
             except Exception as e:
                 print(f"[Sheets] ERROR: Could not append receipt to worksheet: {e}")
+        elif not normalized_date:
+            # Undated receipts dedupe on (vendor, amount) alone, so a genuinely
+            # distinct purchase can be mistaken for a duplicate. Warn instead of
+            # dropping silently (issue #49).
+            vendor = receipt.get("vendor") or "Unknown vendor"
+            amount = receipt.get("amount") or 0
+            print(
+                f"  [Sheets] NOTE: Skipped an undated receipt matching an "
+                f"existing 'Unknown Date' entry ({vendor}, ${amount:.2f}). "
+                f"If this is a distinct purchase, add it manually — undated "
+                f"receipts with the same vendor and amount can't be told apart."
+            )
 
     print(f"\n[Sheets] Upload complete. Added {new_receipts_count} new receipt(s).")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "receipt-ranger"
-version = "0.11.2"
+version = "0.11.3"
 description = "Receipt scanner that extracts structured data from receipt images using BAML and LLMs"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sheets.py
+++ b/sheets.py
@@ -85,11 +85,14 @@ def get_existing_receipts(worksheet: gspread.Worksheet) -> set:
         # "Amount", "Date", "Vendor", "Category".
 
         # To make it more robust, we check if the keys exist.
-        date = record.get("Date")
+        date = record.get("Date") or ""
         amount = record.get("Amount")
         vendor = record.get("Vendor")
 
-        if date and amount and vendor:
+        # Track receipts even when the date is blank (the "Unknown Date"
+        # worksheet, issue #49) so they still dedupe against future uploads.
+        # The empty-string date keeps them distinct from any dated receipt.
+        if amount and vendor:
             existing_receipts.add(
                 (_format_date_for_sheets(str(date)), str(amount), str(vendor))
             )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,8 +3,6 @@
 import os
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 # Import app at module load time so app.py's top-level load_dotenv() runs during
 # collection (in a normal frame) rather than lazily inside a test function. When
 # the first `from app import ...` happens inside a pytest test frame, dotenv's
@@ -412,10 +410,11 @@ class TestUploadToGoogleSheets:
             }
         ]
 
-        count, errors = upload_to_google_sheets(receipts)
+        count, errors, notices = upload_to_google_sheets(receipts)
 
         assert count == 1
         assert len(errors) == 0
+        assert len(notices) == 0
         mock_append.assert_called_once()
 
     @patch("sheets.get_existing_receipts")
@@ -441,9 +440,44 @@ class TestUploadToGoogleSheets:
             }
         ]
 
-        count, errors = upload_to_google_sheets(receipts)
+        count, errors, notices = upload_to_google_sheets(receipts)
 
         assert count == 0  # Already exists, not uploaded
+        # Dated duplicates are skipped silently (a true duplicate).
+        assert len(notices) == 0
+
+    @patch("sheets.append_receipt")
+    @patch("sheets.get_existing_receipts")
+    @patch("sheets.get_or_create_worksheet")
+    @patch("sheets.get_gspread_client")
+    def test_warns_on_skipped_undated_duplicate(
+        self, mock_client, mock_worksheet, mock_existing, mock_append
+    ):
+        mock_client.return_value = MagicMock()
+        mock_worksheet.return_value = MagicMock()
+        # An undated receipt with this vendor/amount already exists in the
+        # "Unknown Date" tab (empty date token in the key).
+        mock_existing.return_value = {("", "25.5", "Test Store")}
+
+        from app import upload_to_google_sheets
+
+        receipts = [
+            {
+                "date": "",
+                "amount": 25.5,
+                "vendor": "Test Store",
+                "category": [],
+                "excludeFromTable": False,
+            }
+        ]
+
+        count, errors, notices = upload_to_google_sheets(receipts)
+
+        assert count == 0  # Treated as a duplicate, not uploaded
+        assert len(notices) == 1
+        assert "undated receipt" in notices[0].lower()
+        assert "Test Store" in notices[0]
+        mock_append.assert_not_called()
 
     @patch("sheets.get_gspread_client")
     def test_handles_auth_error(self, mock_client):
@@ -460,7 +494,7 @@ class TestUploadToGoogleSheets:
             }
         ]
 
-        count, errors = upload_to_google_sheets(receipts)
+        count, errors, notices = upload_to_google_sheets(receipts)
 
         assert count == 0
         assert len(errors) == 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -571,3 +571,118 @@ class TestFutureDateValidation:
         assert result["date"] == ""
         captured = capsys.readouterr()
         assert "Future date detected" in captured.out
+
+
+def _make_mock_receipt(**overrides):
+    """Build a mock BAML receipt with sensible defaults for overriding."""
+    receipt = MagicMock()
+    receipt.isValidReceipt = overrides.get("isValidReceipt", True)
+    receipt.validationError = overrides.get("validationError", "")
+    receipt.id = overrides.get("id", "r1")
+    receipt.amount = overrides.get("amount", 25.50)
+    receipt.date = overrides.get("date", "01/20/2026")
+    receipt.vendor = overrides.get("vendor", "Test Store")
+    receipt.category = overrides.get("category", [])
+    receipt.paymentMethod = overrides.get("paymentMethod", ["Card"])
+    receipt.excludeFromTable = overrides.get("excludeFromTable", False)
+    receipt.exclusionReason = overrides.get("exclusionReason", "")
+    return receipt
+
+
+class TestDateRetry:
+    """Tests for the retry-once-on-missing-date behavior (issue #49)."""
+
+    @patch("main.b")
+    def test_no_retry_when_date_present(self, mock_b, tmp_path):
+        img = tmp_path / "receipt.jpg"
+        img.write_bytes(b"fake image bytes")
+        mock_b.ExtractReceiptFromImage.return_value = _make_mock_receipt(
+            date="01/20/2026"
+        )
+
+        result = main.extract_receipt(str(img), "No exclusion criteria.")
+
+        assert result["date"] == "01/20/2026"
+        mock_b.ExtractReceiptFromImage.assert_called_once()
+
+    @patch("main.b")
+    def test_retry_fills_in_date(self, mock_b, tmp_path, capsys):
+        img = tmp_path / "receipt.jpg"
+        img.write_bytes(b"fake image bytes")
+        first = _make_mock_receipt(date="", amount=25.50, vendor="Test Store")
+        retry = _make_mock_receipt(date="02/02/2026", amount=99.99, vendor="Other")
+        mock_b.ExtractReceiptFromImage.side_effect = [first, retry]
+
+        result = main.extract_receipt(str(img), "No exclusion criteria.")
+
+        # The date comes from the retry, but other fields stay from the first
+        # extraction so a good initial read is not regressed.
+        assert result["date"] == "02/02/2026"
+        assert result["amount"] == 25.50
+        assert result["vendor"] == "Test Store"
+        assert mock_b.ExtractReceiptFromImage.call_count == 2
+        assert "retrying extraction once" in capsys.readouterr().out
+
+    @patch("main.b")
+    def test_retry_still_empty_keeps_blank(self, mock_b, tmp_path):
+        img = tmp_path / "receipt.jpg"
+        img.write_bytes(b"fake image bytes")
+        mock_b.ExtractReceiptFromImage.side_effect = [
+            _make_mock_receipt(date="", vendor="Test Store"),
+            _make_mock_receipt(date="", vendor="Test Store"),
+        ]
+
+        result = main.extract_receipt(str(img), "No exclusion criteria.")
+
+        assert result["date"] == ""
+        assert result["vendor"] == "Test Store"
+        assert mock_b.ExtractReceiptFromImage.call_count == 2
+
+    @patch("main.b")
+    def test_retry_invalid_keeps_first_result(self, mock_b, tmp_path):
+        img = tmp_path / "receipt.jpg"
+        img.write_bytes(b"fake image bytes")
+        mock_b.ExtractReceiptFromImage.side_effect = [
+            _make_mock_receipt(date="", amount=12.0, vendor="Test Store"),
+            _make_mock_receipt(isValidReceipt=False, date="03/03/2026"),
+        ]
+
+        result = main.extract_receipt(str(img), "No exclusion criteria.")
+
+        assert result["isValidReceipt"] is True
+        assert result["date"] == ""
+        assert result["amount"] == 12.0
+        assert mock_b.ExtractReceiptFromImage.call_count == 2
+
+    @patch("main.b")
+    def test_future_date_triggers_retry(self, mock_b, tmp_path):
+        img = tmp_path / "receipt.jpg"
+        img.write_bytes(b"fake image bytes")
+        mock_b.ExtractReceiptFromImage.side_effect = [
+            _make_mock_receipt(date="12/31/2099"),  # future -> blanked
+            _make_mock_receipt(date="04/04/2026"),
+        ]
+
+        result = main.extract_receipt(str(img), "No exclusion criteria.")
+
+        assert result["date"] == "04/04/2026"
+        assert mock_b.ExtractReceiptFromImage.call_count == 2
+
+
+class TestResolveWorksheetForDate:
+    """Tests for routing receipts to month vs. "Unknown Date" worksheets."""
+
+    def test_valid_date_routes_to_month(self):
+        title, normalized = main._resolve_worksheet_for_date("01/20/2026")
+        assert title == "January 2026"
+        assert normalized == "01/20/2026"
+
+    def test_empty_date_routes_to_unknown(self):
+        title, normalized = main._resolve_worksheet_for_date("")
+        assert title == "Unknown Date"
+        assert normalized == ""
+
+    def test_unparseable_date_routes_to_unknown(self):
+        title, normalized = main._resolve_worksheet_for_date("not-a-date")
+        assert title == "Unknown Date"
+        assert normalized == ""

--- a/tests/test_sheets.py
+++ b/tests/test_sheets.py
@@ -1,6 +1,8 @@
 """Tests for sheets.py helper functions."""
 
-from sheets import _format_date_for_sheets
+from unittest.mock import MagicMock
+
+from sheets import _format_date_for_sheets, get_existing_receipts
 
 
 class TestFormatDateForSheets:
@@ -30,3 +32,49 @@ class TestFormatDateForSheets:
 
     def test_double_digit_month_and_day(self):
         assert _format_date_for_sheets("12/31/2026") == "12/31/2026"
+
+
+class TestGetExistingReceipts:
+    """Existing-receipt tracking, including the "Unknown Date" tab (issue #49)."""
+
+    def _worksheet_with(self, records):
+        worksheet = MagicMock()
+        worksheet.get_all_records.return_value = records
+        return worksheet
+
+    def test_tracks_dated_receipts(self):
+        worksheet = self._worksheet_with(
+            [{"Date": "1/20/2026", "Amount": "25.5", "Vendor": "Walmart"}]
+        )
+        existing = get_existing_receipts(worksheet)
+        assert ("1/20/2026", "25.5", "Walmart") in existing
+
+    def test_tracks_dateless_receipts(self):
+        """Rows with a blank date (Unknown Date tab) are still tracked."""
+        worksheet = self._worksheet_with(
+            [{"Date": "", "Amount": "25.5", "Vendor": "Walmart"}]
+        )
+        existing = get_existing_receipts(worksheet)
+        assert ("", "25.5", "Walmart") in existing
+
+    def test_dateless_distinct_from_dated(self):
+        """A blank-date receipt does not collide with a dated one."""
+        worksheet = self._worksheet_with(
+            [
+                {"Date": "", "Amount": "25.5", "Vendor": "Walmart"},
+                {"Date": "1/20/2026", "Amount": "25.5", "Vendor": "Walmart"},
+            ]
+        )
+        existing = get_existing_receipts(worksheet)
+        assert ("", "25.5", "Walmart") in existing
+        assert ("1/20/2026", "25.5", "Walmart") in existing
+        assert len(existing) == 2
+
+    def test_skips_rows_missing_amount_or_vendor(self):
+        worksheet = self._worksheet_with(
+            [
+                {"Date": "", "Amount": "", "Vendor": "Walmart"},
+                {"Date": "", "Amount": "25.5", "Vendor": ""},
+            ]
+        )
+        assert get_existing_receipts(worksheet) == set()


### PR DESCRIPTION
Fixes a problem where receipts with no date would not be entered in the Google Sheets even if the rest of the data were perfectly captured. Now such a receipt would be entered in the Google Sheets under a new tab called "Unknown Date". That way, the user only has to manually input the date of this receipt rather than manually inputting the whole thing. 

- **fix: retry once on missing date, route undated receipts to Unknown Date tab**
- **docs: close CFS bug 11 (date retry + Unknown Date tab done)**
- **chore: sync CFS bug 14 status from GitHub (closed remotely)**
- **Bump version: 0.11.2 → 0.11.3**
- **feat: advise user when an undated receipt is skipped as a duplicate**
