### PR TITLE
fix/normalize vendor duplicates

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.0
+current_version = 0.13.1
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/.cursor/bugs/17-DONE-normalize-vendor-names-to-prevent-casing-based-duplicate-receipts.md
+++ b/.cursor/bugs/17-DONE-normalize-vendor-names-to-prevent-casing-based-duplicate-receipts.md
@@ -69,3 +69,5 @@ casing.
   not the CLI's `processed_receipts.json` content-hash path.
 
 ## Acceptance criteria
+
+<!-- DONE -->

--- a/.cursor/bugs/17-normalize-vendor-names-to-prevent-casing-based-duplicate-receipts.md
+++ b/.cursor/bugs/17-normalize-vendor-names-to-prevent-casing-based-duplicate-receipts.md
@@ -1,0 +1,71 @@
+---
+github_issue: 84
+---
+# Normalize Vendor Names To Prevent Casing Based Duplicate Receipts
+
+## Working directory
+
+`~/Desktop/receipt-ranger`
+
+## Contents
+
+## Summary
+
+Google Sheets duplicate detection fails to flag receipts that are identical
+except for the **casing of the vendor name**. The same receipt uploaded twice
+(once with the vendor in mixed case, once in all caps) is written to the sheet
+twice instead of being flagged as a duplicate.
+
+## How it was found
+
+While validating HEIC→JPEG conversion, I uploaded a receipt that had previously
+been processed (manually converted to JPEG). I expected Receipt Ranger to flag
+it as a duplicate and refuse to write it to Google Sheets. Instead it wrote a
+second row.
+
+The two rows are identical apart from vendor casing:
+
+| Row | Amount | Date      | Vendor                  |
+|-----|--------|-----------|-------------------------|
+| 38  | 27.86  | 5/27/2026 | `BaanThai Thai Cuisine` |
+| 47  | 27.86  | 5/27/2026 | `BAANTHAI THAI CUISINE` |
+
+Same amount, same date — only the vendor case differs.
+
+## Root cause
+
+Duplicate detection keys receipts on `(date, amount, vendor)` but compares the
+vendor as a raw string with no normalization, on **both** sides of the check:
+
+- `sheets.py:97` — existing-sheet receipts keyed on `str(vendor)`
+- `sheets.py:290` — incoming receipt keyed on `str(receipt.get("vendor", ""))`
+
+Because the LLM extraction can return the vendor in different casing across runs
+(and different source images), the two keys don't match and the duplicate slips
+through.
+
+## Proposed fix
+
+Normalize the vendor before building the dedupe key, applied consistently on
+both sides (`get_all_existing_receipts` and `check_receipts_for_duplicates`).
+At minimum: `vendor.strip().casefold()`. Consider also collapsing internal
+whitespace (`" ".join(vendor.split())`) so e.g. double spaces don't defeat the
+match. Normalization should affect **only the comparison key**, not the value
+written to the sheet — the displayed vendor name should keep its original
+casing.
+
+## Acceptance criteria
+
+- Uploading the same receipt where the only difference is vendor casing is
+  flagged as a duplicate and not written to Google Sheets.
+- The vendor name written to the sheet retains its original (LLM-extracted)
+  casing — normalization is comparison-only.
+- Unit tests cover case-insensitive and whitespace-insensitive vendor matching
+  in both `get_all_existing_receipts` and `check_receipts_for_duplicates`.
+
+## Notes
+
+- This affects the Google Sheets dedup path (owner / `ENABLE_GOOGLE_SHEETS`),
+  not the CLI's `processed_receipts.json` content-hash path.
+
+## Acceptance criteria

--- a/.cursor/bugs/18-normalize-amount-formatting-to-prevent-duplicate-receipts-255-vs-2550.md
+++ b/.cursor/bugs/18-normalize-amount-formatting-to-prevent-duplicate-receipts-255-vs-2550.md
@@ -1,0 +1,68 @@
+---
+github_issue: 85
+---
+# Normalize Amount Formatting To Prevent Duplicate Receipts 255 Vs 2550
+
+## Working directory
+
+`~/Desktop/receipt-ranger`
+
+## Contents
+
+## Summary
+
+Google Sheets duplicate detection compares the **amount** as a raw string, so
+two receipts with the same numeric amount but different string formatting do
+not match. For example an incoming receipt with amount `25.5` (float) builds
+the key `"25.5"`, while the same receipt already in the sheet is read back by
+gspread as `"25.50"` — the keys differ and the duplicate is not flagged.
+
+## Background
+
+Found during the QA review of the vendor-casing dedupe fix (CFS bug #17 /
+GitHub #84). That fix normalized the **vendor** component of the dedupe key.
+The **amount** component has an analogous latent gap that predates the vendor
+fix and was left out of scope intentionally.
+
+## Root cause
+
+Both sides of the dedupe key stringify the amount without numeric
+normalization:
+
+- `sheets.py` `get_existing_receipts` — existing rows keyed on `str(amount)`
+  (gspread returns sheet values as strings such as `"25.50"`).
+- `sheets.py` `check_receipts_for_duplicates` — incoming receipts keyed on
+  `str(receipt.get("amount", ""))` (the LLM/Pydantic amount is a float, so
+  `25.5` -> `"25.5"`).
+
+`"25.5" != "25.50"`, so the duplicate slips through. Trailing zeros,
+integer-vs-float (`25` vs `25.0`), and currency symbols / thousands separators
+would all defeat the match the same way.
+
+## Proposed fix
+
+Normalize the amount to a canonical numeric form before building the dedupe
+key, applied consistently on both sides (mirroring how `_normalize_vendor`
+was added for the vendor). Suggested approach: a `_normalize_amount` helper
+that parses to a number and formats to a fixed precision, e.g.
+`f"{float(amount):.2f}"`, with a safe fallback (return the stripped raw string)
+when the value can't be parsed. As with the vendor fix, normalization should
+affect **only the comparison key**, not the value written to the sheet.
+
+## Acceptance criteria
+
+- A receipt with amount `25.5` is flagged as a duplicate of an existing sheet
+  row showing `25.50` (same date + vendor).
+- Integer/float variants (`25` vs `25.0` vs `25.00`) dedupe to one key.
+- Unparseable amounts degrade gracefully (no crash; fall back to string compare).
+- The amount written to the sheet is unchanged (normalization is
+  comparison-only).
+- Unit tests cover amount normalization in both `get_existing_receipts` and
+  `check_receipts_for_duplicates`.
+
+## Notes
+
+- This affects the Google Sheets dedup path, not the CLI's
+  `processed_receipts.json` content-hash path.
+
+## Acceptance criteria

--- a/.cursor/features/13-DONE-convert-heic-images-to-jpeg.md
+++ b/.cursor/features/13-DONE-convert-heic-images-to-jpeg.md
@@ -14,4 +14,6 @@ Include automatic functionality that converts HEIC images to JPEG. Whenever the 
 
 ## Acceptance criteria
 
-- When a user uploads an HEIC receipt image to the application, the application will convert it to JPEG and then process it as it normally would. 
+- When a user uploads an HEIC receipt image to the application, the application will convert it to JPEG and then process it as it normally would.
+
+<!-- DONE -->

--- a/app.py
+++ b/app.py
@@ -1021,7 +1021,7 @@ def main_app():
     st.markdown(
         (
             '<div class="gn-footer">'
-            'Receipt Ranger · <span class="version">v0.13.0</span> · '
+            'Receipt Ranger · <span class="version">v0.13.1</span> · '
             "Structured data from receipt images."
             "</div>"
         ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "receipt-ranger"
-version = "0.13.0"
+version = "0.13.1"
 description = "Receipt scanner that extracts structured data from receipt images using BAML and LLMs"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sheets.py
+++ b/sheets.py
@@ -23,6 +23,18 @@ def _format_date_for_sheets(date_str: str) -> str:
     return date_str
 
 
+def _normalize_vendor(vendor: Any) -> str:
+    """Normalize a vendor name for duplicate-detection comparisons only.
+
+    The LLM can return the same vendor in different casing or spacing across
+    runs (e.g. "BaanThai Thai Cuisine" vs "BAANTHAI THAI CUISINE"), which would
+    otherwise defeat dedupe. We casefold and collapse internal whitespace so
+    such variants compare equal. This affects ONLY the comparison key — the
+    original vendor string is still what gets written to the sheet.
+    """
+    return " ".join(str(vendor or "").split()).casefold()
+
+
 # Name of the credentials file. This file should be in the project root.
 SERVICE_ACCOUNT_FILE = "service_account.json"
 # The name of the Google Sheet to use.
@@ -94,7 +106,11 @@ def get_existing_receipts(worksheet: gspread.Worksheet) -> set:
         # The empty-string date keeps them distinct from any dated receipt.
         if amount and vendor:
             existing_receipts.add(
-                (_format_date_for_sheets(str(date)), str(amount), str(vendor))
+                (
+                    _format_date_for_sheets(str(date)),
+                    str(amount),
+                    _normalize_vendor(vendor),
+                )
             )
 
     return existing_receipts
@@ -287,7 +303,7 @@ def check_receipts_for_duplicates(
         receipt_key = (
             _format_date_for_sheets(str(receipt.get("date", ""))),
             str(receipt.get("amount", "")),
-            str(receipt.get("vendor", "")),
+            _normalize_vendor(receipt.get("vendor", "")),
         )
         if receipt_key in existing:
             duplicates.append(receipt)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -782,8 +782,9 @@ class TestSheetsIntegration:
 
         assert len(result) == 1
         # get_existing_receipts() normalizes the date via _format_date_for_sheets,
-        # dropping leading zeros: "01/20/2026" -> "1/20/2026".
-        assert ("1/20/2026", "25.50", "Test Store") in result
+        # dropping leading zeros ("01/20/2026" -> "1/20/2026"), and casefolds the
+        # vendor for case-insensitive dedupe ("Test Store" -> "test store").
+        assert ("1/20/2026", "25.50", "test store") in result
 
     def test_check_receipts_for_duplicates(self):
         from sheets import check_receipts_for_duplicates
@@ -793,9 +794,10 @@ class TestSheetsIntegration:
         # Patch get_all_existing_receipts within the test
         with patch("sheets.get_all_existing_receipts") as mock_existing:
             # get_all_existing_receipts returns normalized dates (no leading
-            # zeros), so the stored key is "1/20/2026" — matching the key that
+            # zeros) and casefolded vendors, so the stored key is
+            # ("1/20/2026", "25.5", "test store") — matching the key that
             # check_receipts_for_duplicates builds from the receipt below.
-            mock_existing.return_value = {("1/20/2026", "25.5", "Test Store")}
+            mock_existing.return_value = {("1/20/2026", "25.5", "test store")}
 
             receipts = [
                 {"date": "01/20/2026", "amount": 25.5, "vendor": "Test Store"},

--- a/tests/test_sheets.py
+++ b/tests/test_sheets.py
@@ -2,7 +2,11 @@
 
 from unittest.mock import MagicMock
 
-from sheets import _format_date_for_sheets, get_existing_receipts
+from sheets import (
+    _format_date_for_sheets,
+    _normalize_vendor,
+    get_existing_receipts,
+)
 
 
 class TestFormatDateForSheets:
@@ -47,7 +51,8 @@ class TestGetExistingReceipts:
             [{"Date": "1/20/2026", "Amount": "25.5", "Vendor": "Walmart"}]
         )
         existing = get_existing_receipts(worksheet)
-        assert ("1/20/2026", "25.5", "Walmart") in existing
+        # Vendor is normalized (casefolded) in the dedupe key.
+        assert ("1/20/2026", "25.5", "walmart") in existing
 
     def test_tracks_dateless_receipts(self):
         """Rows with a blank date (Unknown Date tab) are still tracked."""
@@ -55,7 +60,7 @@ class TestGetExistingReceipts:
             [{"Date": "", "Amount": "25.5", "Vendor": "Walmart"}]
         )
         existing = get_existing_receipts(worksheet)
-        assert ("", "25.5", "Walmart") in existing
+        assert ("", "25.5", "walmart") in existing
 
     def test_dateless_distinct_from_dated(self):
         """A blank-date receipt does not collide with a dated one."""
@@ -66,9 +71,39 @@ class TestGetExistingReceipts:
             ]
         )
         existing = get_existing_receipts(worksheet)
-        assert ("", "25.5", "Walmart") in existing
-        assert ("1/20/2026", "25.5", "Walmart") in existing
+        assert ("", "25.5", "walmart") in existing
+        assert ("1/20/2026", "25.5", "walmart") in existing
         assert len(existing) == 2
+
+    def test_vendor_casing_collapses_to_one_key(self):
+        """Same receipt with different vendor casing dedupes to one entry."""
+        worksheet = self._worksheet_with(
+            [
+                {
+                    "Date": "5/27/2026",
+                    "Amount": "27.86",
+                    "Vendor": "BaanThai Thai Cuisine",
+                },
+                {
+                    "Date": "5/27/2026",
+                    "Amount": "27.86",
+                    "Vendor": "BAANTHAI THAI CUISINE",
+                },
+            ]
+        )
+        existing = get_existing_receipts(worksheet)
+        assert existing == {("5/27/2026", "27.86", "baanthai thai cuisine")}
+
+    def test_vendor_whitespace_collapses_to_one_key(self):
+        """Extra/internal whitespace in the vendor does not defeat dedupe."""
+        worksheet = self._worksheet_with(
+            [
+                {"Date": "5/27/2026", "Amount": "27.86", "Vendor": "Baan Thai"},
+                {"Date": "5/27/2026", "Amount": "27.86", "Vendor": "  Baan   Thai "},
+            ]
+        )
+        existing = get_existing_receipts(worksheet)
+        assert existing == {("5/27/2026", "27.86", "baan thai")}
 
     def test_skips_rows_missing_amount_or_vendor(self):
         worksheet = self._worksheet_with(
@@ -78,3 +113,72 @@ class TestGetExistingReceipts:
             ]
         )
         assert get_existing_receipts(worksheet) == set()
+
+
+class TestNormalizeVendor:
+    def test_casefolds(self):
+        assert _normalize_vendor("BAANTHAI THAI CUISINE") == "baanthai thai cuisine"
+
+    def test_collapses_internal_whitespace(self):
+        assert _normalize_vendor("Baan   Thai") == "baan thai"
+
+    def test_strips_surrounding_whitespace(self):
+        assert _normalize_vendor("  Walmart  ") == "walmart"
+
+    def test_casing_and_whitespace_variants_match(self):
+        assert _normalize_vendor("BaanThai Thai Cuisine") == _normalize_vendor(
+            "  BAANTHAI   THAI CUISINE "
+        )
+
+    def test_none_returns_empty_string(self):
+        assert _normalize_vendor(None) == ""
+
+    def test_non_string_is_coerced(self):
+        assert _normalize_vendor(123) == "123"
+
+
+class TestCheckReceiptsForDuplicates:
+    """End-to-end dedupe: incoming receipts vs. existing sheet rows."""
+
+    def _client_with_rows(self, rows):
+        worksheet = MagicMock()
+        worksheet.get_all_records.return_value = rows
+        spreadsheet = MagicMock()
+        spreadsheet.worksheets.return_value = [worksheet]
+        client = MagicMock()
+        client.open.return_value = spreadsheet
+        return client
+
+    def test_flags_vendor_casing_duplicate(self):
+        """The reported bug: same receipt, vendor casing differs -> duplicate."""
+        from sheets import check_receipts_for_duplicates
+
+        client = self._client_with_rows(
+            [
+                {
+                    "Date": "5/27/2026",
+                    "Amount": "27.86",
+                    "Vendor": "BaanThai Thai Cuisine",
+                }
+            ]
+        )
+        incoming = [
+            {
+                "date": "5/27/2026",
+                "amount": "27.86",
+                "vendor": "BAANTHAI THAI CUISINE",
+            }
+        ]
+        dupes = check_receipts_for_duplicates(client, incoming)
+        assert dupes == incoming
+
+    def test_distinct_vendor_not_flagged(self):
+        from sheets import check_receipts_for_duplicates
+
+        client = self._client_with_rows(
+            [{"Date": "5/27/2026", "Amount": "27.86", "Vendor": "BaanThai"}]
+        )
+        incoming = [
+            {"date": "5/27/2026", "amount": "27.86", "vendor": "Sonic Drive-In"}
+        ]
+        assert check_receipts_for_duplicates(client, incoming) == []


### PR DESCRIPTION
Fix a bug where vendor names weren't being normalized, so the same vendor name with different casing or spacing was not being properly counted as a duplicate. Duplicates were making it into the sheet. 

- **fix: normalize vendor names to prevent casing-based duplicate receipts**
- **docs: add CFS bug docs #17/#18 and mark HEIC feature done**
- **docs: mark CFS bug #17 done**
