### PR TITLE
fix: uploader chips/thumbnails mismatch (bug #19)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.14.0
+current_version = 0.14.1
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/.cursor/bugs/19-DONE-mismatch-between-file-picker-icons-and-thumbnail-images-listed-below.md
+++ b/.cursor/bugs/19-DONE-mismatch-between-file-picker-icons-and-thumbnail-images-listed-below.md
@@ -25,3 +25,5 @@ I tried fixing this before, but it kept introducing even worse bugs, so this has
 - No CSS hiding of the native file chips and no `st.rerun()` after upload (the
   two approaches that caused regressions in past attempts: an empty dropzone
   and a 5-10s mobile delay).
+
+<!-- DONE -->

--- a/.cursor/bugs/19-mismatch-between-file-picker-icons-and-thumbnail-images-listed-below.md
+++ b/.cursor/bugs/19-mismatch-between-file-picker-icons-and-thumbnail-images-listed-below.md
@@ -9,8 +9,19 @@ github_issue: 90
 
 ## Contents
 
-Right now there's a mismatch between the file picker icons and the thumbnail icons listed below. For example, you can have two file picker icons, but only one thumbnail, and when you clear a file picker icon, it doesn't clear the thumbnail. For a valid MVP, this must be fixed. 
+Right now there's a mismatch between the file picker icons and the thumbnail icons listed below. For example, you can have two file picker icons display, but only one thumbnail, and when you clear a file picker icon, it doesn't clear the thumbnail. For a valid MVP, this must be fixed. 
 
 I tried fixing this before, but it kept introducing even worse bugs, so this has to be fixed carefully.
 
 ## Acceptance criteria
+
+- The thumbnail grid always matches the uploader's file chips one-to-one (same
+  files, same names).
+- Removing a file via the X on its chip removes its thumbnail on the next
+  render.
+- Uploading the same content twice shows both chips and both thumbnails (one
+  marked "duplicate"); the duplicate is only processed once.
+- "Clear all" empties both the chips and the thumbnails.
+- No CSS hiding of the native file chips and no `st.rerun()` after upload (the
+  two approaches that caused regressions in past attempts: an empty dropzone
+  and a 5-10s mobile delay).

--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,4 @@ __marimo__/
 # Temporary files and folders
 tmp/
 .grepai/
+.gstack/

--- a/app.py
+++ b/app.py
@@ -1078,7 +1078,7 @@ def main_app():
     st.markdown(
         (
             '<div class="gn-footer">'
-            'Receipt Ranger · <span class="version">v0.14.0</span> · '
+            'Receipt Ranger · <span class="version">v0.14.1</span> · '
             "Structured data from receipt images."
             "</div>"
         ),

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 """Receipt Ranger - Streamlit Frontend"""
 
 import base64
+import hashlib
 import os
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 
@@ -147,10 +148,12 @@ def get_mime_type(filename: str) -> str | None:
 
 def init_session_state():
     """Initialize session state variables."""
-    if "uploaded_files" not in st.session_state:
-        st.session_state.uploaded_files = {}
     if "uploader_key" not in st.session_state:
         st.session_state.uploader_key = 0
+    if "heic_cache" not in st.session_state:
+        st.session_state.heic_cache = {}
+    if "upload_signature" not in st.session_state:
+        st.session_state.upload_signature = None
     if "processing_results" not in st.session_state:
         st.session_state.processing_results = []
     if "processing_complete" not in st.session_state:
@@ -171,22 +174,12 @@ def init_session_state():
         st.session_state.api_provider = "OpenAI"
 
 
-def remove_file(filename: str):
-    """Remove a file from the upload queue."""
-    if filename in st.session_state.uploaded_files:
-        del st.session_state.uploaded_files[filename]
-    # Reset the uploader widget so Streamlit doesn't re-emit removed files.
-    st.session_state.uploader_key += 1
-    reset_processing()
-
-
 def clear_all_files():
-    """Clear all uploaded files."""
-    st.session_state.uploaded_files = {}
+    """Clear all uploaded files by resetting the uploader widget."""
     st.session_state.uploader_key += 1
-    st.session_state.processing_results = []
-    st.session_state.processing_complete = False
-    st.session_state.duplicates_found = []
+    st.session_state.heic_cache = {}
+    st.session_state.upload_signature = None
+    reset_processing()
 
 
 def reset_processing():
@@ -196,26 +189,96 @@ def reset_processing():
     st.session_state.duplicates_found = []
 
 
-def queue_uploaded_file(filename: str, file_bytes: bytes, mime_type: str) -> bool:
-    """Queue an uploaded file with collision-safe naming.
+def _convert_heic_cached(file_bytes: bytes, filename: str, mime_type: str, digest: str):
+    """Convert a HEIC upload to JPEG, caching by content hash.
 
-    Returns:
-        True when a new file was queued, False when it was an exact duplicate.
+    Streamlit reruns the whole script on every interaction, so without a cache
+    each rerun would re-convert every queued HEIC file. The cache entry is
+    ("ok", bytes, mime) on success or ("error", message, None) on failure.
     """
-    # Skip exact duplicate content already in the queue.
-    for existing_bytes, _ in st.session_state.uploaded_files.values():
-        if existing_bytes == file_bytes:
-            return False
+    cached = st.session_state.heic_cache.get(digest)
+    if cached is None:
+        try:
+            converted_bytes, converted_mime = maybe_convert_heic(
+                file_bytes, filename, mime_type
+            )
+            cached = ("ok", converted_bytes, converted_mime)
+        except HEICConversionError as e:
+            cached = ("error", str(e), None)
+        st.session_state.heic_cache[digest] = cached
+    return cached
 
-    base, ext = os.path.splitext(filename)
-    candidate = filename
-    suffix = 2
-    while candidate in st.session_state.uploaded_files:
-        candidate = f"{base} ({suffix}){ext}"
-        suffix += 1
 
-    st.session_state.uploaded_files[candidate] = (file_bytes, mime_type)
-    return True
+def build_upload_queue(uploaded) -> list[dict]:
+    """Project the uploader widget's current files into a processing queue.
+
+    The widget is the single source of truth (issue #19): this projection is
+    recomputed on every rerun, so the preview grid always matches the native
+    file chips one-to-one and removing a chip removes its thumbnail. Each
+    entry is a dict with:
+        name: original filename, exactly as shown on the widget's chip
+        bytes/mime: payload to send for processing (HEIC converted to JPEG)
+        sha256: content hash of the original upload
+        duplicate: True when an earlier entry has identical content
+        error: reason this entry can't be processed, or None
+    """
+    entries = []
+    seen_hashes = set()
+
+    for file in uploaded or []:
+        file_bytes = file.getvalue()
+        digest = hashlib.sha256(file_bytes).hexdigest()
+        entry = {
+            "name": file.name,
+            "bytes": file_bytes,
+            "mime": get_mime_type(file.name),
+            "sha256": digest,
+            "duplicate": digest in seen_hashes,
+            "error": None,
+        }
+        seen_hashes.add(digest)
+
+        if entry["mime"] is None:
+            entry["error"] = "Unsupported file type"
+        elif is_heic_filename(file.name):
+            # HEIC isn't reliably decoded by the upstream LLM providers, so
+            # convert it to JPEG transparently before processing.
+            cached = _convert_heic_cached(file_bytes, file.name, entry["mime"], digest)
+            if cached[0] == "ok":
+                entry["bytes"], entry["mime"] = cached[1], cached[2]
+            else:
+                entry["error"] = f"Could not convert HEIC file: {cached[1]}"
+
+        entries.append(entry)
+
+    # Drop cached conversions for files no longer in the widget so the cache
+    # can't grow without bound over a long session. Re-adding a removed HEIC
+    # file just costs one re-conversion.
+    stale = set(st.session_state.heic_cache) - seen_hashes
+    for digest in stale:
+        del st.session_state.heic_cache[digest]
+
+    return entries
+
+
+def files_to_process(queue: list[dict]) -> dict:
+    """Build the processing dict from queue entries, with collision-safe names.
+
+    Skips exact-content duplicates and entries that failed conversion, so each
+    receipt is only sent to the LLM once.
+    """
+    files = {}
+    for entry in queue:
+        if entry["duplicate"] or entry["error"]:
+            continue
+        base, ext = os.path.splitext(entry["name"])
+        candidate = entry["name"]
+        suffix = 2
+        while candidate in files:
+            candidate = f"{base} ({suffix}){ext}"
+            suffix += 1
+        files[candidate] = (entry["bytes"], entry["mime"])
+    return files
 
 
 def set_api_key_env():
@@ -338,11 +401,11 @@ def upload_to_google_sheets(receipts: list[dict]) -> tuple[int, list[str], list[
     return uploaded_count, errors, notices
 
 
-def process_receipts(files_to_process: dict, provider: str = "Anthropic") -> list[dict]:
+def process_receipts(files: dict, provider: str = "Anthropic") -> list[dict]:
     """Process uploaded receipt files.
 
     Args:
-        files_to_process: Dict mapping filename to (bytes, mime_type)
+        files: Dict mapping filename to (bytes, mime_type)
         provider: LLM provider to use ("Anthropic" or "OpenAI")
 
     Returns:
@@ -351,7 +414,7 @@ def process_receipts(files_to_process: dict, provider: str = "Anthropic") -> lis
     exclusion_criteria = load_exclusion_criteria()
     results = []
 
-    for filename, (file_bytes, mime_type) in files_to_process.items():
+    for filename, (file_bytes, mime_type) in files.items():
         try:
             # Encode to base64
             image_data = base64.standard_b64encode(file_bytes).decode("utf-8")
@@ -365,8 +428,6 @@ def process_receipts(files_to_process: dict, provider: str = "Anthropic") -> lis
             receipt_data["source_file"] = filename
 
             # Compute hash for state tracking
-            import hashlib
-
             h = hashlib.sha256()
             h.update(file_bytes)
             receipt_data["source_hash"] = h.hexdigest()
@@ -564,34 +625,14 @@ def render_sidebar(cookie=None) -> bool:
         return sheets_available
 
 
-def render_file_upload():
-    """Render the file upload section."""
-    st.subheader("Upload receipts")
+def render_file_upload() -> list[dict]:
+    """Render the file upload section and return the derived queue.
 
-    st.markdown(
-        """
-        <style>
-        /* Hide native file list rendered by Streamlit's file uploader.
-           We render our own thumbnail grid in render_file_preview(). */
-        [data-testid="stFileUploader"] [data-testid="stFileUploaderFile"] {
-            display: none !important;
-        }
-        [data-testid="stFileUploader"] [data-testid="stFileUploaderFileName"] {
-            display: none !important;
-        }
-        [data-testid="stFileUploader"] [data-testid="stFileUploaderDeleteBtn"] {
-            display: none !important;
-        }
-        [data-testid="stFileUploaderFileList"] {
-            display: none !important;
-        }
-        [data-testid="stFileUploaderFileList"] img {
-            display: none !important;
-        }
-        </style>
-        """,
-        unsafe_allow_html=True,
-    )
+    The native file chips (with their X buttons) stay visible: they are the
+    per-file removal UI, and the thumbnail grid below is derived from the
+    same widget value so the two can never disagree (issue #19).
+    """
+    st.subheader("Upload receipts")
 
     uploaded = st.file_uploader(
         "Drop receipt images here",
@@ -601,45 +642,31 @@ def render_file_upload():
         help="Supported formats: JPG, PNG, GIF, BMP, WebP, TIFF, HEIC",
     )
 
-    # Process newly uploaded files
-    any_added = False
-    if uploaded:
-        for file in uploaded:
-            mime_type = get_mime_type(file.name)
-            if not mime_type:
-                continue
-            file_bytes = file.getvalue()
-            display_name = file.name
+    queue = build_upload_queue(uploaded)
 
-            # HEIC isn't reliably decoded by the upstream LLM providers, so
-            # convert it to JPEG transparently before queueing. The user sees
-            # the converted filename in the preview so it's clear what will
-            # be sent for processing.
-            if is_heic_filename(file.name):
-                try:
-                    file_bytes, mime_type = maybe_convert_heic(
-                        file_bytes, file.name, mime_type
-                    )
-                except HEICConversionError as e:
-                    st.error(f"Could not convert HEIC file `{file.name}`: {e}")
-                    continue
-                base, _ = os.path.splitext(file.name)
-                display_name = f"{base}.jpg"
-
-            any_added = (
-                queue_uploaded_file(display_name, file_bytes, mime_type) or any_added
-            )
-
-    if any_added:
+    # Reset stale processing results whenever the processable files change
+    # (a file added or a chip removed), but not on unrelated reruns. Duplicate
+    # and error entries are excluded: adding an exact duplicate or an
+    # unprocessable file can't change the results, so it shouldn't wipe them.
+    signature = tuple(
+        entry["sha256"]
+        for entry in queue
+        if not entry["duplicate"] and not entry["error"]
+    )
+    if signature != st.session_state.upload_signature:
+        st.session_state.upload_signature = signature
         reset_processing()
 
+    return queue
 
-def render_file_preview():
-    """Render preview of uploaded files with remove buttons."""
-    if not st.session_state.uploaded_files:
+
+def render_file_preview(queue: list[dict]):
+    """Render thumbnails matching the uploader's file chips one-to-one."""
+    if not queue:
         return
 
     st.subheader("Selected files")
+    st.caption("To remove a file, click the X on its entry in the uploader above.")
 
     if st.button("Clear all", key="clear_all", icon=":material/delete_sweep:"):
         clear_all_files()
@@ -647,26 +674,22 @@ def render_file_preview():
 
     cols = st.columns(3)
 
-    for idx, (filename, (file_bytes, mime_type)) in enumerate(
-        st.session_state.uploaded_files.items()
-    ):
-        col = cols[idx % 3]
+    for idx, entry in enumerate(queue):
+        filename = entry["name"]
+        caption = filename[:20] + "..." if len(filename) > 20 else filename
 
-        with col:
-            with st.container():
-                caption = filename[:20] + "..." if len(filename) > 20 else filename
-                st.image(file_bytes, caption=caption, width=150)
-
-                if st.button(
-                    "Remove", key=f"remove_{filename}", icon=":material/close:"
-                ):
-                    remove_file(filename)
-                    st.rerun()
+        with cols[idx % 3]:
+            if entry["error"]:
+                st.warning(f"`{caption}` — {entry['error']}")
+            elif entry["duplicate"]:
+                st.image(entry["bytes"], caption=f"{caption} (duplicate)", width=150)
+            else:
+                st.image(entry["bytes"], caption=caption, width=150)
 
 
-def render_submit_section(sheets_available: bool):
+def render_submit_section(sheets_available: bool, queue: list[dict]):
     """Render the submit button and processing section."""
-    if not st.session_state.uploaded_files:
+    if not queue:
         st.info("Upload receipt images to get started.")
         return
 
@@ -676,7 +699,22 @@ def render_submit_section(sheets_available: bool):
 
     st.divider()
 
-    num_files = len(st.session_state.uploaded_files)
+    files = files_to_process(queue)
+    num_duplicates = sum(1 for e in queue if e["duplicate"] and not e["error"])
+    num_errors = sum(1 for e in queue if e["error"])
+
+    if num_duplicates:
+        st.caption(
+            f"{num_duplicates} exact duplicate file(s) will only be processed once."
+        )
+    if num_errors:
+        st.caption(f"{num_errors} file(s) cannot be processed and will be skipped.")
+
+    if not files:
+        st.warning("None of the uploaded files can be processed.")
+        return
+
+    num_files = len(files)
     submit_label = f"Process {num_files} receipt{'s' if num_files > 1 else ''}"
 
     if st.button(
@@ -685,15 +723,20 @@ def render_submit_section(sheets_available: bool):
         key="submit_btn",
         icon=":material/play_arrow:",
     ):
-        process_and_display_results(sheets_available)
+        process_and_display_results(sheets_available, files)
 
 
-def process_and_display_results(sheets_available: bool):
-    """Process receipts and display results."""
+def process_and_display_results(sheets_available: bool, files: dict):
+    """Process receipts and display results.
+
+    Args:
+        sheets_available: Whether Google Sheets upload is available.
+        files: Dict mapping filename to (file_bytes, mime_type).
+    """
     # Set the API key in environment
     set_api_key_env()
 
-    num_files = len(st.session_state.uploaded_files)
+    num_files = len(files)
 
     # Create a prominent processing container
     processing_container = st.container()
@@ -710,9 +753,7 @@ def process_and_display_results(sheets_available: bool):
         results = []
         exclusion_criteria = load_exclusion_criteria()
 
-        for idx, (filename, (file_bytes, mime_type)) in enumerate(
-            st.session_state.uploaded_files.items()
-        ):
+        for idx, (filename, (file_bytes, mime_type)) in enumerate(files.items()):
             # Update progress
             progress = (idx) / num_files
             progress_bar.progress(progress)
@@ -741,8 +782,6 @@ def process_and_display_results(sheets_available: bool):
                 receipt_data["source_file"] = filename
 
                 # Compute hash for state tracking
-                import hashlib
-
                 h = hashlib.sha256()
                 h.update(file_bytes)
                 receipt_data["source_hash"] = h.hexdigest()
@@ -1005,9 +1044,9 @@ def main_app():
 
     render_header()
 
-    render_file_upload()
-    render_file_preview()
-    render_submit_section(sheets_available)
+    queue = render_file_upload()
+    render_file_preview(queue)
+    render_submit_section(sheets_available, queue)
 
     if st.session_state.processing_complete and st.session_state.processing_results:
         valid_receipts = [

--- a/app.py
+++ b/app.py
@@ -75,6 +75,11 @@ OWNER_ANTHROPIC_API_KEY = os.environ.get("OWNER_ANTHROPIC_API_KEY", "")
 # Timeout (in seconds) for a single LLM receipt-processing call.
 RECEIPT_PROCESSING_TIMEOUT = 60
 
+# Maximum number of files accepted per upload batch. Bounds memory held per
+# session and LLM spend on the public endpoint; files beyond the limit are
+# flagged in the preview and skipped, never read into the queue.
+MAX_UPLOAD_FILES = 20
+
 # API-key cookie persistence durations (in seconds). The Fernet-encrypted key
 # token is stored in a browser cookie; these control how long it survives.
 # SESSION_ONLY_MAX_AGE is None: no cookie is written at all (the library cannot
@@ -225,7 +230,20 @@ def build_upload_queue(uploaded) -> list[dict]:
     entries = []
     seen_hashes = set()
 
-    for file in uploaded or []:
+    for idx, file in enumerate(uploaded or []):
+        if idx >= MAX_UPLOAD_FILES:
+            entries.append(
+                {
+                    "name": file.name,
+                    "bytes": b"",
+                    "mime": None,
+                    "sha256": f"over-limit-{idx}",
+                    "duplicate": False,
+                    "error": f"Upload limit is {MAX_UPLOAD_FILES} files",
+                }
+            )
+            continue
+
         file_bytes = file.getvalue()
         digest = hashlib.sha256(file_bytes).hexdigest()
         entry = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "receipt-ranger"
-version = "0.14.0"
+version = "0.14.1"
 description = "Receipt scanner that extracts structured data from receipt images using BAML and LLMs"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -584,6 +584,26 @@ class TestUploadQueue:
         assert [e["duplicate"] for e in queue] == [False, True, True]
         assert len(files_to_process(queue)) == 1
 
+    @patch("app.st")
+    def test_files_beyond_upload_limit_are_flagged_and_skipped(self, mock_st):
+        mock_st.session_state.heic_cache = {}
+
+        from app import MAX_UPLOAD_FILES, build_upload_queue, files_to_process
+
+        uploads = [
+            FakeUpload(f"r{i}.jpg", f"content-{i}".encode())
+            for i in range(MAX_UPLOAD_FILES + 2)
+        ]
+        queue = build_upload_queue(uploads)
+
+        # Every chip still gets a queue entry (1:1 preview invariant)...
+        assert len(queue) == MAX_UPLOAD_FILES + 2
+        over_limit = queue[MAX_UPLOAD_FILES:]
+        assert all("Upload limit" in e["error"] for e in over_limit)
+        # ...but over-limit files are never read or processed.
+        assert all(e["bytes"] == b"" for e in over_limit)
+        assert len(files_to_process(queue)) == MAX_UPLOAD_FILES
+
     @patch("app.maybe_convert_heic")
     @patch("app.st")
     def test_heic_cache_prunes_entries_for_removed_files(self, mock_st, mock_convert):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -449,33 +449,205 @@ class TestProcessReceipts:
         assert "Processing error" in results[0]["validationError"]
 
 
-class TestUploadQueueing:
+class FakeUpload:
+    """Minimal stand-in for Streamlit's UploadedFile."""
+
+    def __init__(self, name: str, data: bytes):
+        self.name = name
+        self._data = data
+
+    def getvalue(self) -> bytes:
+        return self._data
+
+
+class TestUploadQueue:
+    """Tests for the widget-derived upload queue (issue #19).
+
+    The queue is a pure projection of the uploader widget's current value,
+    so thumbnails always match the native file chips one-to-one.
+    """
+
     @patch("app.st")
-    def test_same_filename_different_content_gets_unique_name(self, mock_st):
-        mock_st.session_state.uploaded_files = {}
+    def test_queue_matches_widget_files_one_to_one(self, mock_st):
+        mock_st.session_state.heic_cache = {}
 
-        from app import queue_uploaded_file
+        from app import build_upload_queue
 
-        added_first = queue_uploaded_file("receipt.jpg", b"first", "image/jpeg")
-        added_second = queue_uploaded_file("receipt.jpg", b"second", "image/jpeg")
+        queue = build_upload_queue(
+            [FakeUpload("a.jpg", b"one"), FakeUpload("b.png", b"two")]
+        )
 
-        assert added_first is True
-        assert added_second is True
-        assert "receipt.jpg" in mock_st.session_state.uploaded_files
-        assert "receipt (2).jpg" in mock_st.session_state.uploaded_files
+        assert [e["name"] for e in queue] == ["a.jpg", "b.png"]
+        assert all(e["error"] is None for e in queue)
+        assert all(e["duplicate"] is False for e in queue)
 
     @patch("app.st")
-    def test_exact_duplicate_content_is_ignored(self, mock_st):
-        mock_st.session_state.uploaded_files = {}
+    def test_empty_or_none_widget_value_yields_empty_queue(self, mock_st):
+        mock_st.session_state.heic_cache = {}
 
-        from app import queue_uploaded_file
+        from app import build_upload_queue
 
-        added_first = queue_uploaded_file("receipt.jpg", b"same", "image/jpeg")
-        added_second = queue_uploaded_file("other-name.jpg", b"same", "image/jpeg")
+        assert build_upload_queue(None) == []
+        assert build_upload_queue([]) == []
 
-        assert added_first is True
-        assert added_second is False
-        assert len(mock_st.session_state.uploaded_files) == 1
+    @patch("app.st")
+    def test_removing_a_file_removes_its_queue_entry(self, mock_st):
+        """Simulates clicking the X on a native chip: the widget re-emits the
+        remaining files and the derived queue (thus thumbnails) must match."""
+        mock_st.session_state.heic_cache = {}
+
+        from app import build_upload_queue
+
+        first = build_upload_queue(
+            [FakeUpload("a.jpg", b"one"), FakeUpload("b.jpg", b"two")]
+        )
+        after_remove = build_upload_queue([FakeUpload("b.jpg", b"two")])
+
+        assert len(first) == 2
+        assert [e["name"] for e in after_remove] == ["b.jpg"]
+
+    @patch("app.st")
+    def test_exact_duplicate_content_is_marked_but_still_listed(self, mock_st):
+        mock_st.session_state.heic_cache = {}
+
+        from app import build_upload_queue, files_to_process
+
+        queue = build_upload_queue(
+            [FakeUpload("receipt.jpg", b"same"), FakeUpload("other.jpg", b"same")]
+        )
+
+        # Both entries stay in the queue (matching both chips)...
+        assert len(queue) == 2
+        assert queue[0]["duplicate"] is False
+        assert queue[1]["duplicate"] is True
+        # ...but the duplicate is only processed once.
+        assert list(files_to_process(queue).keys()) == ["receipt.jpg"]
+
+    @patch("app.st")
+    def test_same_filename_different_content_gets_unique_processing_name(self, mock_st):
+        mock_st.session_state.heic_cache = {}
+
+        from app import build_upload_queue, files_to_process
+
+        queue = build_upload_queue(
+            [FakeUpload("receipt.jpg", b"first"), FakeUpload("receipt.jpg", b"second")]
+        )
+        files = files_to_process(queue)
+
+        assert set(files.keys()) == {"receipt.jpg", "receipt (2).jpg"}
+
+    @patch("app.st")
+    def test_unsupported_extension_is_flagged_and_skipped(self, mock_st):
+        mock_st.session_state.heic_cache = {}
+
+        from app import build_upload_queue, files_to_process
+
+        queue = build_upload_queue([FakeUpload("notes.txt", b"hello")])
+
+        assert queue[0]["error"] == "Unsupported file type"
+        assert files_to_process(queue) == {}
+
+    @patch("app.maybe_convert_heic")
+    @patch("app.st")
+    def test_heic_is_converted_and_cached_across_reruns(self, mock_st, mock_convert):
+        mock_st.session_state.heic_cache = {}
+        mock_convert.return_value = (b"jpeg-bytes", "image/jpeg")
+
+        from app import build_upload_queue
+
+        upload = [FakeUpload("photo.heic", b"heic-bytes")]
+        queue = build_upload_queue(upload)
+        # Second build simulates a Streamlit rerun with the same widget value.
+        queue_again = build_upload_queue(upload)
+
+        assert queue[0]["bytes"] == b"jpeg-bytes"
+        assert queue[0]["mime"] == "image/jpeg"
+        assert queue[0]["name"] == "photo.heic"  # caption matches the chip
+        assert queue_again[0]["bytes"] == b"jpeg-bytes"
+        mock_convert.assert_called_once()
+
+    @patch("app.st")
+    def test_three_identical_files_process_once(self, mock_st):
+        mock_st.session_state.heic_cache = {}
+
+        from app import build_upload_queue, files_to_process
+
+        queue = build_upload_queue(
+            [
+                FakeUpload("a.jpg", b"same"),
+                FakeUpload("b.jpg", b"same"),
+                FakeUpload("c.jpg", b"same"),
+            ]
+        )
+
+        assert len(queue) == 3
+        assert [e["duplicate"] for e in queue] == [False, True, True]
+        assert len(files_to_process(queue)) == 1
+
+    @patch("app.maybe_convert_heic")
+    @patch("app.st")
+    def test_heic_cache_prunes_entries_for_removed_files(self, mock_st, mock_convert):
+        """Removing a HEIC file's chip must also evict its cached conversion."""
+        mock_st.session_state.heic_cache = {}
+        mock_convert.return_value = (b"jpeg-bytes", "image/jpeg")
+
+        from app import build_upload_queue
+
+        build_upload_queue([FakeUpload("photo.heic", b"heic-bytes")])
+        assert len(mock_st.session_state.heic_cache) == 1
+
+        # Rerun after the user removed the chip: widget value is empty.
+        build_upload_queue([])
+        assert mock_st.session_state.heic_cache == {}
+
+    def test_clear_all_files_resets_uploader_and_caches(self):
+        class FakeSessionState(dict):
+            def __getattr__(self, k):
+                if k in self:
+                    return self[k]
+                raise AttributeError(k)
+
+            def __setattr__(self, k, v):
+                self[k] = v
+
+        fake = FakeSessionState()
+        fake["uploader_key"] = 3
+        fake["heic_cache"] = {"digest": ("ok", b"x", "image/jpeg")}
+        fake["upload_signature"] = ("digest",)
+        fake["processing_results"] = [{"vendor": "Old"}]
+        fake["processing_complete"] = True
+        fake["duplicates_found"] = [{"vendor": "Old"}]
+
+        with patch("app.st") as mock_st:
+            mock_st.session_state = fake
+            from app import clear_all_files
+
+            clear_all_files()
+
+        assert fake["uploader_key"] == 4  # widget reset clears the chips
+        assert fake["heic_cache"] == {}
+        assert fake["upload_signature"] is None
+        assert fake["processing_results"] == []
+        assert fake["processing_complete"] is False
+        assert fake["duplicates_found"] == []
+
+    @patch("app.maybe_convert_heic")
+    @patch("app.st")
+    def test_heic_conversion_failure_is_flagged_and_skipped(
+        self, mock_st, mock_convert
+    ):
+        from image_conversion import HEICConversionError
+
+        mock_st.session_state.heic_cache = {}
+        mock_convert.side_effect = HEICConversionError("bad file")
+
+        from app import build_upload_queue, files_to_process
+
+        queue = build_upload_queue([FakeUpload("photo.heic", b"heic-bytes")])
+
+        assert queue[0]["error"] is not None
+        assert "bad file" in queue[0]["error"]
+        assert files_to_process(queue) == {}
 
 
 class TestCheckForDuplicates:
@@ -646,16 +818,15 @@ class TestReceiptProcessingTimeout:
         mock_extract.side_effect = slow_extract
 
         mock_st.session_state = MagicMock()
-        mock_st.session_state.uploaded_files = {
-            "slow.jpg": (b"fake", "image/jpeg"),
-        }
         mock_st.session_state.api_provider = "OpenAI"
         mock_st.session_state.processing_results = []
         mock_st.session_state.processing_complete = False
 
         from app import process_and_display_results
 
-        process_and_display_results(sheets_available=False)
+        process_and_display_results(
+            sheets_available=False, files={"slow.jpg": (b"fake", "image/jpeg")}
+        )
 
         # Unblock the orphaned thread so it cleans up quickly.
         event.set()
@@ -684,9 +855,6 @@ class TestReceiptProcessingTimeout:
         }
 
         mock_st.session_state = MagicMock()
-        mock_st.session_state.uploaded_files = {
-            "fast.jpg": (b"fake", "image/jpeg"),
-        }
         mock_st.session_state.api_provider = "Anthropic"
         mock_st.session_state.processing_results = []
         mock_st.session_state.processing_complete = False
@@ -694,7 +862,9 @@ class TestReceiptProcessingTimeout:
 
         from app import process_and_display_results
 
-        process_and_display_results(sheets_available=False)
+        process_and_display_results(
+            sheets_available=False, files={"fast.jpg": (b"fake", "image/jpeg")}
+        )
 
         results = mock_st.session_state.processing_results
         assert len(results) == 1
@@ -739,17 +909,19 @@ class TestReceiptProcessingTimeout:
         mock_extract.side_effect = mixed_extract
 
         mock_st.session_state = MagicMock()
-        mock_st.session_state.uploaded_files = {
-            "slow.jpg": (b"fake1", "image/jpeg"),
-            "fast.jpg": (b"fake2", "image/jpeg"),
-        }
         mock_st.session_state.api_provider = "OpenAI"
         mock_st.session_state.processing_results = []
         mock_st.session_state.processing_complete = False
 
         from app import process_and_display_results
 
-        process_and_display_results(sheets_available=False)
+        process_and_display_results(
+            sheets_available=False,
+            files={
+                "slow.jpg": (b"fake1", "image/jpeg"),
+                "fast.jpg": (b"fake2", "image/jpeg"),
+            },
+        )
         event.set()
 
         results = mock_st.session_state.processing_results


### PR DESCRIPTION
Derives thumbnails from the uploader widget so chips and previews always match. Includes a 20-file upload cap (security hardening) and the v0.14.1 bump.